### PR TITLE
feat(strategic-thinking): add 5 Cs strategic thinking skill and integrate into agents

### DIFF
--- a/agents/design-specialist/AGENT.md
+++ b/agents/design-specialist/AGENT.md
@@ -3,7 +3,7 @@ name: design-specialist
 description: Use this agent when you need to convert design references into production-ready CMS code for WordPress or Drupal projects. This agent should be used proactively when users provide Figma URLs, screenshots, or design mockups and want them implemented as WordPress block patterns or Drupal paragraph types. It orchestrates complete design-to-code workflows by analyzing design inputs, generating responsive CMS components, spawning responsive-styling-specialist for CSS generation, creating test pages, spawning browser-validator-specialist for comprehensive validation, and reporting detailed technical results with file paths and specifications.
 
 tools: Read, Glob, Grep, Bash, Write, Edit, Task, ToolSearch, figma MCP, chrome-devtools MCP, playwright MCP
-skills: design-analyzer, responsive-styling
+skills: design-analyzer, responsive-styling, strategic-thinking
 model: sonnet
 color: purple
 ---
@@ -386,6 +386,16 @@ Use the field mapping to generate:
 4. SCSS styles based on design specifications
 
 Download image assets to: `modules/custom/{module}/assets/images/{paragraph-name}/`
+
+#### Step 3: Choose Implementation Approach
+
+Before detecting MCP availability, apply the **5 Cs of Strategic Thinking** (from the `strategic-thinking` skill) when the implementation path is unclear or a significant trade-off exists:
+
+- **Context** — Does the project have constraints that favor one approach? (e.g., production deployment pipeline, team familiarity with YAML config, CI/CD that imports config automatically)
+- **Cost** — MCP-based creation is faster to execute but requires MCP availability; YAML generation requires a manual import step but is portable and version-controllable
+- **Consequence** — If MCP tools fail mid-creation, can the work be recovered? YAML files are always inspectable; MCP state may not be
+
+When the path is truly unclear, surface the trade-off to the user rather than silently defaulting.
 
 #### Step 3: Detect Drupal MCP Availability
 ```bash

--- a/agents/live-audit-specialist/AGENT.md
+++ b/agents/live-audit-specialist/AGENT.md
@@ -539,6 +539,18 @@ Comprehensive site audit complete.
 The report includes detailed findings from all four specialists, prioritized remediation roadmap, and specific fixes for each issue.
 ```
 
+## Strategic Decision Framework
+
+When synthesizing audit findings into a remediation roadmap or launch recommendation, apply the **5 Cs of Strategic Thinking** (from the `strategic-thinking` skill) to validate your reasoning:
+
+- **Consequence** — What's at stake if each issue ships? What breaks for real users? Does inaction create legal, security, or reputational risk?
+- **Connective Tissue** — Which issues amplify each other? A performance regression combined with a slow database query compounds worse than either alone. Pull the thread before assigning priority.
+- **Cost** — Is it realistic to fix all critical issues before the launch date? If not, name that explicitly and let the team decide — don't quietly downgrade priority.
+- **Context** — Is there history with this site that changes severity? (e.g., a known CVE that's already been exploited, or an a11y issue on a government site with compliance requirements)
+- **Color** — Be explicit about your confidence level and whether the recommendation is a "must fix" or "strong advisory." Ambiguity in launch decisions creates risk.
+
+Use these Cs to explain *why* issues are categorized as critical vs. high vs. medium — not just what the rules say, but what's actually at stake for this specific site.
+
 ## Launch Readiness Decision Tree
 
 ```

--- a/agents/workflow-specialist/AGENT.md
+++ b/agents/workflow-specialist/AGENT.md
@@ -3,7 +3,7 @@ name: workflow-specialist
 description: Use this agent when you need to orchestrate pull request workflows for Drupal or WordPress projects. This agent should be used proactively when users have staged changes and need commit messages, want to create pull requests, need code review, or are preparing releases. It generates conventional commit messages from staged changes, creates comprehensive PR descriptions, analyzes PR changes for review, coordinates release management with changelogs, and delegates to testing-specialist, security-specialist, and accessibility-specialist for comprehensive quality checks before PR creation.
 
 tools: Read, Glob, Grep, Bash, Task, Write, Edit
-skills: commit-message-generator
+skills: commit-message-generator, strategic-thinking
 model: sonnet
 color: purple
 ---
@@ -551,6 +551,17 @@ Create release PR with changelog and deployment checklist.
 - Verify `gh` authentication: `gh auth status`
 - Suggest: Manual PR creation steps
 - Provide: Generated description for copy-paste
+
+## Strategic Decision Framework
+
+When deciding whether to block a PR, proceed conditionally, or escalate — apply the **5 Cs of Strategic Thinking** (from the `strategic-thinking` skill):
+
+- **Color** — Is this a production release or an exploratory branch? The urgency and seriousness of a quality gate scales with what's actually shipping. Don't treat a feature exploration branch like a production hotfix, or vice versa.
+- **Consequence** — What breaks if this ships with known issues? Who is affected, and how severely? An inaccessible checkout flow has different stakes than a missing docblock.
+- **Cost** — If specialists found issues that require significant rework, name the cost explicitly before the user decides whether to proceed or revise scope.
+- **Connective Tissue** — Does this PR touch code that other in-flight PRs depend on? Flag that before creating so the team has context.
+
+Use these Cs to provide a recommendation, not just a checklist. "Gate passed" and "gate failed" are outputs — the *why* is what helps the team make the right call.
 
 ## Quality Gates
 

--- a/docs/agents-and-skills.md
+++ b/docs/agents-and-skills.md
@@ -116,7 +116,8 @@ Each agent uses specific skills for detailed "how-to" knowledge:
 | documentation-specialist | documentation-generator |
 | code-quality-specialist | code-standards-checker |
 | teamwork-specialist | teamwork-task-creator, teamwork-integrator, teamwork-exporter |
-| live-audit-specialist | (none - pure orchestrator) |
+| live-audit-specialist | strategic-thinking |
+| design-specialist | design-analyzer, responsive-styling, strategic-thinking |
 
 ### Why Agents?
 
@@ -552,6 +553,53 @@ Creating tasks now...
 
 ---
 
+### 13. strategic-thinking
+
+**Automatically triggers when you:**
+- Ask "should we do this?" or "is this the right approach?"
+- Say "help me decide" or "help me think through this"
+- Ask "what are the trade-offs?" or "pros and cons?"
+- Are weighing options about architecture, tooling, platform, or delegating work
+- Face a prioritization or go/no-go decision
+
+**What it does:**
+- Guides you through Brene Brown's 5 Cs of Strategic Thinking from *Strong Ground*
+- Works through Context, Color, Connective Tissue, Cost, and Consequence conversationally
+- Asks 1–2 focused questions per C to surface what's known and what's missing
+- Synthesizes findings into a structured analysis with a clear recommendation
+
+**The 5 Cs:**
+- **Context** — History, parallel work, stakeholder expectations, prerequisites
+- **Color** — Vision of success, urgency, ideation vs. committed decision
+- **Connective Tissue** — Dependencies, ripple effects, anticipatory thinking
+- **Cost** — Time, money, bandwidth, focus, opportunity cost
+- **Consequence** — Stakes, cost of inaction, risk of getting it wrong
+
+**Example:**
+```
+You: "Should we migrate to headless for this project?"
+Claude: "Let's think through this with the 5 Cs. Context first: has the team
+tried headless before, or is there a reason the current architecture was chosen?"
+
+[... works through each C ...]
+
+## Strategic Analysis: Headless Architecture Decision
+
+### Context
+- Previous attempt abandoned due to editorial complexity — root cause not resolved
+
+### Consequence
+- Repeating the same failure has high organizational cost
+
+## Recommendation
+Defer until editorial workflow requirements are defined.
+Confidence: High | Next step: Document editorial requirements first
+```
+
+**Related Command:** None — this skill activates conversationally for any significant decision
+
+---
+
 ## How to Use Agent Skills
 
 ### Natural Conversation
@@ -640,6 +688,7 @@ Don't try to "game" the system—just describe what you need:
 | teamwork-task-creator | "create task", "make ticket" | Single task creation | `/teamwork create` |
 | teamwork-integrator | "PROJ-123", "status of" | Quick lookups | `/teamwork status` |
 | teamwork-exporter | "export to Teamwork" | Audit export | `/teamwork export` |
+| strategic-thinking | "should we do this?", "help me decide" | Decision making | None |
 
 ## Integration with Workflow
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -155,6 +155,12 @@ Detailed instructions for Claude on how to execute this skill...
 3. **Detailed instructions** - Provide step-by-step workflow
 4. **Examples** - Show expected interactions
 
+### 10. strategic-thinking
+
+**Triggers**: "should we do this?", "help me decide", "what are the trade-offs", "help me think through this", "is this the right approach?", "pros and cons", "help me think through"
+**Purpose**: Guide significant decisions using Brene Brown's 5 Cs of Strategic Thinking (Context, Color, Connective Tissue, Cost, Consequence) from *Strong Ground*
+**Related Command**: None — skill-only
+
 ## Adding New Skills
 
 To add a new Agent Skill:

--- a/skills/strategic-thinking/SKILL.md
+++ b/skills/strategic-thinking/SKILL.md
@@ -1,0 +1,305 @@
+---
+name: strategic-thinking
+description: Automatically guide users through Brene Brown's 5 Cs of Strategic Thinking (Context, Color, Connective Tissue, Cost, Consequence) when making significant decisions. From the book "Strong Ground" by Brene Brown. Invoke when user asks "should we do this?", "help me decide", "what are the trade-offs", "help me think through this", "is this the right approach?", or is weighing options about architecture, tooling, features, project approach, or delegating work.
+---
+
+# Strategic Thinking with the 5 Cs
+
+Guide significant decisions using Brene Brown's 5 Cs framework from *Strong Ground*.
+
+## Philosophy
+
+Good decisions don't come from gut instinct alone — they come from slowing down long enough to see the full picture. Brene Brown's 5 Cs of Strategic Thinking, Decision Making, and Delegating provide a structured way to surface what's known, what's missing, and what's at stake before committing to a course of action.
+
+### Core Beliefs
+
+1. **Clarity Before Commitment**: The cost of pausing to think is almost always lower than the cost of reversing a poor decision
+2. **Missing Information Is Risk**: An unanswered C is not a neutral gap — it's a known unknown that should be named and managed
+3. **Decisions Have Ripples**: Every technical or strategic choice connects to past decisions and future possibilities — pull the thread
+4. **Intent Shapes Everything**: A decision made with clear color (vision + urgency) is far easier to execute and course-correct than one made in ambiguity
+5. **This Works at Every Scale**: Whether you're choosing a CSS approach or recommending a full platform migration, the 5 Cs apply
+
+### Why This Framework
+
+In CMS development work, most difficult decisions share the same failure modes: incomplete context, unclear intent, ignored dependencies, underestimated cost, and unconsidered consequences. The 5 Cs address each failure mode directly.
+
+## When to Use This Skill
+
+Activate this skill when the user:
+- Asks "should we do this?" or "is this the right approach?"
+- Says "help me decide" or "help me think through this"
+- Is weighing options (architecture, tooling, CMS platform, tech stack, vendors)
+- Is considering delegating a task or responsibility
+- Asks "what are the trade-offs?"
+- Faces a prioritization decision (which issues to fix first, which features to build)
+- Is about to make a significant irreversible decision
+- Mentions "pros and cons" or "not sure if we should"
+- Is preparing for a stakeholder conversation about direction
+
+## Do NOT Activate For
+
+- Simple factual questions ("what does this function do?")
+- Routine implementation tasks with a clear path forward
+- Debugging specific errors
+- Minor style or formatting choices
+
+## The 5 Cs Framework
+
+These are Brene Brown's 5 Cs of Strategic Thinking, Decision Making, and Delegating from *Strong Ground*.
+
+### 1. Context
+
+No one has optics on everything happening in an organization. Context ensures you're not making decisions in a vacuum.
+
+**Key questions:**
+- What's happening in other areas that will impact or be impacted by this decision?
+- Is there history or previous experience that we need to understand?
+- Is there a broader context to discuss — geopolitics, supply chain, unspoken expectations?
+- Do we need vettings or briefs on partners, vendors, or stakeholders?
+
+**In CMS work, this looks like:**
+- Understanding why a previous approach was abandoned before proposing it again
+- Knowing about an active platform migration before recommending deep customization
+- Checking whether another team is already solving the same problem
+
+### 2. Color
+
+Setting a clear intention and painting the fullest, most detailed picture of what success looks like.
+
+**Key questions:**
+- Can you describe your vision of what this looks like or how it works?
+- How would you assign the level of importance, seriousness, and urgency?
+- Is this ideation and brainstorming, or are we going to do this?
+- If this is "throwing out ideas," how will we know when or if it moves to a serious plan?
+
+**In CMS work, this looks like:**
+- Distinguishing "we're exploring headless" from "we're migrating to headless by Q3"
+- Defining what "done" looks like for a feature before writing a line of code
+- Clarifying whether a performance concern is theoretical or blocking production
+
+### 3. Connective Tissue
+
+Pull the thread. Every decision connects to other decisions — past, present, and future.
+
+**Key questions:**
+- How does this connect to other plans, strategies, decisions, or deliverables?
+- Does this solve or amplify what's already happened or happening now?
+- How does it lay the groundwork for what hasn't happened yet but is part of the vision?
+- Using anticipatory thinking — what will be the ripple effect of this decision?
+
+**In CMS work, this looks like:**
+- Recognizing that a caching strategy decision affects both performance and editorial workflows
+- Understanding that a third-party API integration creates a long-term dependency
+- Seeing that fixing a security issue in one module may expose the same pattern in five others
+
+### 4. Cost
+
+Decisions are never free. Cost must be named, agreed upon, and communicated.
+
+**Key questions:**
+- What will this cost in terms of money, time, bandwidth, focus, and priority shifts?
+- Is this cost tolerable? Expected? Agreed upon? Controversial? Communicated?
+- Does everyone involved understand the cost AND how we're going to deal with the spend?
+
+**In CMS work, this looks like:**
+- Estimating the engineering time for a "simple" feature that touches core
+- Acknowledging that adding a new dependency has a long-term maintenance cost
+- Being honest that a comprehensive accessibility audit will delay the sprint
+
+### 5. Consequence
+
+What's at stake — for doing this, for not doing this, and for getting it wrong?
+
+**Key questions:**
+- Are there consequences of not doing this, and if so, what are they?
+- What's at stake?
+- What are the consequences of getting it wrong?
+- Are there any unintended consequences that we can anticipate or problem-solve now?
+
+**In CMS work, this looks like:**
+- Recognizing that deferring a security fix creates legal and reputational risk
+- Understanding that a performance regression above a certain threshold triggers SLA penalties
+- Anticipating that a component architecture change will require retraining content editors
+
+## Decision Framework
+
+### Which Cs Are Most Critical by Decision Type?
+
+| Decision Type | Primary Cs | Secondary Cs |
+|---|---|---|
+| Architecture / Platform | Connective Tissue, Consequence | Context, Cost |
+| Feature prioritization | Consequence, Cost | Color, Connective Tissue |
+| Delegation | Color, Cost | Context |
+| Vendor / tool selection | Context, Cost, Consequence | Connective Tissue |
+| Audit remediation priority | Consequence, Connective Tissue | Cost |
+| Release / go-live decisions | Consequence, Color | Cost, Context |
+| Ideation / brainstorming | Color | (all others optional) |
+
+### Depth by Stakes
+
+- **High-stakes, irreversible** — Work all 5 Cs thoroughly
+- **Medium-stakes, reversible** — Focus on the 2–3 most critical Cs for that decision type
+- **Low-stakes, easily changed** — A quick Color check may be sufficient
+
+## Interactive Workflow
+
+When this skill activates, guide the user through the 5 Cs conversationally — don't dump all questions at once. Gather one C at a time, then synthesize.
+
+### Step 1: Name the Decision
+
+Confirm what decision is actually being made. Restate it clearly:
+
+> "It sounds like you're deciding whether to [X]. Is that right, or is there more to it?"
+
+### Step 2: Work Through the 5 Cs
+
+For each C, ask 1–2 focused questions. Wait for answers before moving to the next C. Skip Cs that are clearly not relevant (e.g., don't ask about geopolitical context for a CSS framework choice).
+
+**Suggested question openers:**
+- *Context*: "Before we dig in — is there any history or parallel work we should factor in?"
+- *Color*: "What does success look like here? And is this something we're definitely doing, or still exploring?"
+- *Connective Tissue*: "How does this connect to what's already in motion? What might it affect downstream?"
+- *Cost*: "What's the real cost here — time, focus, money? Who has agreed to absorb that?"
+- *Consequence*: "What happens if we don't do this? And what could go wrong if we do?"
+
+### Step 3: Surface Gaps
+
+After gathering responses, explicitly name any Cs that are unclear or unanswered:
+
+> "We have good clarity on Context and Cost, but the Consequence of not acting isn't fully defined yet. That gap is a risk worth naming."
+
+### Step 4: Synthesize and Recommend
+
+Produce a structured analysis and a clear recommendation.
+
+## Output Format
+
+After gathering information through the 5 Cs, present a structured analysis:
+
+```markdown
+## Strategic Analysis: [Decision Title]
+
+### Context
+- [Key contextual factors: history, parallel work, stakeholder expectations]
+- [Gaps: what context is still unknown]
+
+### Color
+- [Vision of success]
+- [Urgency and importance level]
+- [Ideation vs. committed decision]
+
+### Connective Tissue
+- [Dependencies and connections to existing work]
+- [Anticipated ripple effects]
+- [Groundwork this lays for future decisions]
+
+### Cost
+- [Time, money, bandwidth, focus]
+- [Opportunity cost: what won't get done]
+- [Communication status: who knows and agrees]
+
+### Consequence
+- [Cost of inaction]
+- [Risk of getting it wrong]
+- [Unintended consequences to watch for]
+
+## Recommendation
+
+[Clear recommendation with reasoning]
+
+**Confidence**: High / Medium / Low
+**Key risk**: [The one thing most likely to make this go wrong]
+**Next step**: [Specific, actionable next step]
+```
+
+## Integration with CMS Cultivator
+
+This skill is embedded in three specialist agents at their key decision points:
+
+- **live-audit-specialist** — Applies the 5 Cs when prioritizing remediation roadmaps and making launch recommendations. Consequence and Connective Tissue drive issue severity; Cost validates what's achievable in each sprint.
+
+- **workflow-specialist** — Applies Color and Consequence when deciding whether to block a PR or proceed conditionally. Color distinguishes exploratory PRs from production releases. Consequence surfaces what ships broken if the gate is bypassed.
+
+- **design-specialist** — Applies Context and Cost when choosing between implementation approaches (e.g., MCP-based vs. YAML fallback, block pattern vs. paragraph type variant). Context surfaces project constraints; Cost surfaces the long-term maintenance reality.
+
+## Example Interactions
+
+**Example 1: Architecture decision**
+
+```
+User: "Should we go headless for this project?"
+
+[Skill activates]
+
+"Before we weigh in — let's think through this with the 5 Cs.
+
+Context first: Is there history here? Has the team explored headless before, or is there a reason the current architecture was chosen?"
+
+User: "We tried it 2 years ago and it was abandoned due to editorial complexity."
+
+"Good to know — that history matters a lot.
+
+Color: What does headless success look like for this project specifically? And is this a committed direction or still being explored?"
+
+[... continues through Cost, Connective Tissue, Consequence ...]
+
+## Strategic Analysis: Headless Architecture Decision
+
+### Context
+- Previous headless attempt abandoned due to editorial complexity — root cause not yet resolved
+- ...
+
+## Recommendation
+Defer the headless evaluation until the editorial workflow requirements are defined.
+**Confidence**: High
+**Key risk**: Repeating the previous failure without addressing the root cause
+**Next step**: Document editorial workflow requirements before revisiting the architecture decision
+```
+
+**Example 2: Quick prioritization**
+
+```
+User: "We have 3 critical issues from the audit — security vuln, accessibility failure, and a performance regression. Which do we fix first?"
+
+[Skill activates — recognizes prioritization decision]
+
+"Classic triage question. Let me ask about Consequence and Connective Tissue quickly.
+
+Consequence: Does the security vuln have an active threat or disclosure deadline? Is the a11y failure blocking any users from core functionality? Is the performance regression above an SLA threshold?"
+
+User: "Security is a known CVE, no deadline yet. A11y blocks screen reader users from checkout. Performance is bad but no SLA."
+
+"That's clear. Connective Tissue: does the performance fix involve any of the same code as the security patch?"
+
+User: "No, completely different."
+
+## Recommendation
+Fix order: (1) Accessibility — blocks real users from checkout right now. (2) Security — known CVE with escalating risk. (3) Performance — real but no immediate threshold breach.
+**Confidence**: High
+**Key risk**: Security CVE timeline could accelerate — revisit if a disclosure date emerges
+**Next step**: Open tickets for all three; start a11y fix today
+```
+
+## Best Practices
+
+### DO
+
+- Surface unknown Cs as explicit risks, not omissions — "We don't have clarity on Cost yet, and that's worth naming before we proceed"
+- Keep the interactive conversation focused — one C at a time
+- Name the decision type early to know which Cs to prioritize
+- Provide a clear recommendation, not just a framework dump
+- Give a confidence level so the user knows how solid the recommendation is
+- Acknowledge when a decision is genuinely close and explain what would shift it
+
+### DON'T
+
+- Skip Cs because they seem obvious — obvious answers are worth confirming, not assuming
+- Present all 25 questions at once — this is a conversation, not a form
+- Use the framework as a way to avoid making a recommendation
+- Apply all 5 Cs with equal depth to low-stakes decisions — match depth to stakes
+- Treat the framework as a checklist — it's a thinking tool, not a compliance exercise
+
+## Resources
+
+- *Strong Ground: The Lessons of Daring Leadership, The Tenacity of Paradox, and the Wisdom of the Human Spirit* by Brene Brown
+- Brene Brown's Dare to Lead research: brenebrown.com/daretolead


### PR DESCRIPTION
## Description
Teamwork Ticket(s): N/A
- [x] Was AI used in this pull request?

> As a developer, I need a structured decision-making framework embedded in the plugin so agents and users can reason through significant choices with clarity and rigor.

Adds Brene Brown's 5 Cs of Strategic Thinking (Context, Color, Connective Tissue, Cost, Consequence) from *Strong Ground* as a new agent skill. The skill activates conversationally when users face architectural decisions, prioritization trade-offs, or go/no-go choices. Three specialist agents — `live-audit-specialist`, `workflow-specialist`, and `design-specialist` — now reference the skill at their key decision points.

## Acceptance Criteria
* New `skills/strategic-thinking/SKILL.md` exists with complete 5 Cs workflow, interactive conversation guide, output format, and examples
* `live-audit-specialist` applies the 5 Cs when synthesizing audit findings into a remediation roadmap or launch recommendation
* `workflow-specialist` applies the 5 Cs when deciding whether to block a PR, proceed conditionally, or escalate
* `design-specialist` applies the 5 Cs when choosing between implementation approaches (e.g., MCP vs. YAML)
* `docs/agents-and-skills.md` documents the new skill with trigger phrases, example interaction, and skill-agent mapping table entry
* `skills/README.md` includes the `strategic-thinking` entry in the skills index

## Assumptions
* The 5 Cs are attributed to Brene Brown's *Strong Ground* throughout the skill and agent references
* The skill is conversational-only — no corresponding slash command is needed
* Low-stakes decisions should not trigger the full 5 Cs workflow; the skill includes depth-by-stakes guidance

## Steps to Validate
1. Review `skills/strategic-thinking/SKILL.md` for completeness — all 5 Cs defined, interactive workflow documented, output format shown, two example interactions included
2. Review `agents/live-audit-specialist/AGENT.md` for the Strategic Decision Framework section
3. Review `agents/workflow-specialist/AGENT.md` for the Strategic Decision Framework section
4. Review `agents/design-specialist/AGENT.md` for the updated skills list and Step 3 addition
5. Confirm `docs/agents-and-skills.md` includes skill #13 with trigger phrases and the updated agent-skill mapping table

## Affected URL
N/A — documentation and skill files only

## Deploy Notes
No deployment steps required. This is a documentation-only change — new skill file and agent updates only. No dependencies, scripts, or CMS configuration involved.

---

*Release context: This PR is part of v0.9.0, which also adds GTM performance auditing and structured data auditing capabilities landed via main.*