### PR TITLE
docs(codex): add OpenAI Codex installation and invocation documentation

### DIFF
--- a/.claude/plans/2026-04-28-codex-documentation-updates.md
+++ b/.claude/plans/2026-04-28-codex-documentation-updates.md
@@ -1,0 +1,137 @@
+# Codex Documentation Updates + Full Doc Audit
+
+## Context
+
+CMS Cultivator added OpenAI Codex support in v1.0.0 (April 15, 2026), shipping:
+- `.codex-plugin/plugin.json` — Codex plugin manifest
+- `.codex/agents/` — 17 TOML agent translation files
+- `skills/*/agents/openai.yaml` — invocation policies for 14 skills requiring confirmation
+
+The README.md already reflects multi-platform support ("Works in Claude Code, Claude Desktop, and OpenAI Codex"), but the docs site (`docs/`) still frames the plugin as Claude Code-only. Additionally, `docs/contributing.md` references the removed `commands/` directory (deleted in v1.0.0).
+
+**Codex installation mechanics (from official docs):**
+- Codex reads `.codex-plugin/plugin.json` as the plugin manifest
+- Skills invoke via natural language or `@skill-name` explicitly
+- CLI marketplace: `codex plugin marketplace add owner/repo`
+- Personal install: clone to `~/.codex/plugins/` + add `~/.agents/plugins/marketplace.json`
+- Repo-scoped: copy to `$REPO_ROOT/plugins/` + add `$REPO_ROOT/.agents/plugins/marketplace.json`
+- Config at `~/.codex/config.toml`
+
+---
+
+## Files to Change
+
+### 1. `docs/index.md`
+**Changes:**
+- Line 6: "CMS Cultivator is a comprehensive Claude Code plugin providing 38 Agent Skills" → "CMS Cultivator is a plugin for Claude Code, Claude Desktop, and OpenAI Codex providing 38 Agent Skills"
+- Requirements section (line 135): "Claude Code CLI" → "Claude Code CLI or OpenAI Codex"
+- Add explicit feature bullet for Codex under the features list (alongside the Auto-Invoked / Natural Language bullets — add "Multi-Platform — Works in Claude Code, Claude Desktop, and OpenAI Codex")
+
+### 2. `README.md`
+**Changes:**
+- Requirements section ("Claude Code CLI" under Required) → list as "Claude Code CLI or OpenAI Codex"
+- Quick Start section: keep Claude Code `/plugin` commands as-is, add a "**Codex**" sub-block with:
+  ```bash
+  # Add the kanopi marketplace
+  codex plugin marketplace add kanopi/claude-toolbox
+  # Then open the plugin browser and install CMS Cultivator
+  codex/plugins
+  ```
+
+### 3. `docs/installation.md` (major rewrite)
+**Structure:** Restructure into two top-level sections: **Claude Code** and **OpenAI Codex**.
+
+Keep the existing Methods 1–4 under a `## Claude Code` heading.
+
+Add a `## OpenAI Codex` section with three methods:
+
+**Codex Method 1: Via Marketplace (Recommended)**
+```bash
+# Add the Kanopi marketplace
+codex plugin marketplace add kanopi/claude-toolbox
+# Open the plugin browser
+codex/plugins
+# Browse to CMS Cultivator and select Install plugin
+```
+
+**Codex Method 2: Personal Installation (Manual)**
+```bash
+# Clone to personal Codex plugins directory
+git clone https://github.com/kanopi/cms-cultivator ~/.codex/plugins/cms-cultivator
+```
+Then create/update `~/.agents/plugins/marketplace.json`:
+```json
+{
+  "name": "kanopi-plugins",
+  "plugins": [
+    {
+      "name": "cms-cultivator",
+      "source": { "source": "local", "path": "./cms-cultivator" },
+      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+      "category": "Development"
+    }
+  ]
+}
+```
+Restart Codex, then open `codex/plugins` and install.
+
+**Codex Method 3: Repo-Scoped Installation**
+Copy plugin to `$REPO_ROOT/plugins/cms-cultivator` and add `$REPO_ROOT/.agents/plugins/marketplace.json` (same structure as above). Commit to git for team sharing.
+
+**Codex Verification:**
+- Open a new thread and type `@cms-cultivator` to confirm it's available
+- Or say "Does this follow Drupal coding standards?" — skills activate automatically
+
+**Codex Invocation section:**
+- Natural language: same as Claude Code
+- Explicit: use `@cms-cultivator` or `@skill-name` (e.g. `@pr-create`)
+
+**Prerequisites section:** Update to mention Codex as an alternative platform.
+
+### 4. `docs/contributing.md` (moderate changes)
+**Changes:**
+- Prerequisites: "Claude Code CLI (for testing commands)" → "Claude Code CLI or OpenAI Codex (for testing skills)"
+- Development setup step 4: Add Codex testing alternative alongside Claude Code link
+- Remove the stale **"Adding a New Command"** section entirely (commands/ was deleted in v1.0.0)
+- Replace with **"Adding a New Skill"** section matching the actual workflow from `CLAUDE.md`:
+  1. Create `/skills/feature-name/SKILL.md` with YAML frontmatter
+  2. Test locally (link to plugin in Claude Code or Codex)
+  3. Run `./scripts/validate-frontmatter.sh`
+  4. Update `docs/agents-and-skills.md` if applicable
+- Frontmatter section: remove the stale "Commands" field list (commands were removed), keep Agents and Skills
+
+### 5. `docs/agents-and-skills.md`
+**Changes:**
+- Lines 1-8: Fix the "three-tier architecture" description that lists "Slash Commands" as a tier — slash commands were removed in v1.0.0. Update to two-tier: Specialist Agents + Agent Skills
+- Any other references to slash commands as the user-facing invocation method should be updated to reflect `/skill-name` explicit invocation in Claude Code and `@skill-name` in Codex
+
+### 6. `docs/reference/agent-skills-reference.md`
+**Changes:**
+- Line 5: "replaced custom slash commands as the primary extensibility model for Claude Code plugins" → add "and OpenAI Codex"
+- Lines 36-43: "Installing skills in Claude Code" → add a parallel paragraph for Codex: "Skills in Codex are installed via the plugin system. Install the plugin, then skills load automatically based on context."
+- Line 68: "Skill-creator (available as a Claude Code plugin)" — add "(also available for OpenAI Codex)"
+
+### 7. `docs/quick-start.md`
+**Changes:**
+- Add a brief note near the top (after the two-ways intro) clarifying that `/command` syntax is Claude Code; in Codex, use `@skill-name` for explicit invocation. Natural language works the same on both platforms.
+
+---
+
+## Files NOT Changing
+
+- `docs/commands/overview.md` — already mentions Codex correctly
+- `docs/commands/design-workflow.md` — Figma MCP config is genuinely Claude Code-specific; will add a note that design validation features require Claude Code
+- `docs/project-management/teamwork-integration.md` — MCP-specific, Claude Code only; accurate as-is
+- `docs/commands/live-site-auditing.md` — Chrome DevTools MCP is Claude Code-specific; accurate as-is
+- `docs/wordpress-skills.md` — "Restart Claude Code" instructions are minor and accurate for that context; low priority
+
+---
+
+## Verification
+
+After implementation:
+1. `zensical build --clean` — verify no broken links
+2. `zensical serve` — preview at http://localhost:8000, check Installation and Contributing pages
+3. Confirm `docs/agents-and-skills.md` no longer references the three-tier slash command architecture
+4. Confirm `docs/contributing.md` no longer references `commands/` directory
+5. Confirm `docs/installation.md` has both Claude Code and Codex sections with accurate commands

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Specialist agents and 38 auto-invoked skills for Drupal/WordPress development. W
 
 ## Quick Start
 
-**Via Marketplace (Recommended)**
+**Claude Code — Via Marketplace (Recommended)**
 
 ```bash
 # Add the Claude Toolbox marketplace
@@ -21,10 +21,20 @@ Specialist agents and 38 auto-invoked skills for Drupal/WordPress development. W
 /plugin install cms-cultivator@claude-toolbox
 ```
 
-**Direct Install**
+**Claude Code — Direct Install**
 
 ```bash
 /plugin install https://github.com/kanopi/cms-cultivator
+```
+
+**OpenAI Codex — Via Marketplace**
+
+```bash
+# Add the Kanopi marketplace
+codex plugin marketplace add kanopi/claude-toolbox
+
+# Open the plugin browser and install CMS Cultivator
+codex/plugins
 ```
 
 See [Installation Guide](https://kanopi.github.io/cms-cultivator/installation/) for complete setup instructions.
@@ -140,7 +150,7 @@ Integrates with [Kanopi's DDEV add-ons](https://kanopi.github.io/cms-cultivator/
 ## Requirements
 
 **Required:**
-- Claude Code CLI
+- Claude Code CLI **or** OpenAI Codex
 - Git
 
 **Optional:**

--- a/docs/agents-and-skills.md
+++ b/docs/agents-and-skills.md
@@ -1,10 +1,9 @@
 # Agents and Skills
 
-CMS Cultivator features a three-tier architecture:
+CMS Cultivator features a two-tier architecture:
 
-1. **Specialist Agents** - Orchestrate complex workflows (spawned by commands)
-2. **Slash Commands** - User-facing interfaces (you invoke explicitly)
-3. **Agent Skills** - Knowledge base (Claude invokes automatically during conversation)
+1. **Specialist Agents** - Orchestrate complex workflows (spawned by skills)
+2. **Agent Skills** - Knowledge base (auto-invoked by context, or explicitly invoked)
 
 ---
 
@@ -92,21 +91,21 @@ PR with new features:
       → May spawn accessibility-specialist (if UI tests needed)
 ```
 
-### Agent-to-Command Mapping
+### Agent-to-Skill Mapping (Spawned By)
 
-| Agent | Used By Commands | Can Delegate To |
-|-------|------------------|-----------------|
-| workflow-specialist | `/pr-commit-msg`, `/pr-create`, `/pr-review`, `/pr-release` | testing, security, accessibility |
-| accessibility-specialist | `/audit-a11y` | (none - leaf) |
-| performance-specialist | `/audit-perf` | (none - leaf) |
-| gtm-specialist | `/audit-gtm` | (none - leaf) |
-| security-specialist | `/audit-security` | (none - leaf) |
-| testing-specialist | `/test-generate`, `/test-plan`, `/test-coverage` | security, accessibility |
-| documentation-specialist | `/docs-generate` | (none - leaf) |
-| live-audit-specialist | `/audit-live-site` | performance, accessibility, security, code-quality |
-| code-quality-specialist | `/quality-analyze`, `/quality-standards` | (none - leaf) |
-| structured-data-specialist | `/audit-structured-data` | (none - leaf) |
-| drupal-pantheon-devops-specialist | `/devops-setup` | (none - leaf) |
+| Agent | Spawned By Skills | Can Delegate To |
+|-------|-------------------|-----------------|
+| workflow-specialist | `pr-commit-msg`, `pr-create`, `pr-review`, `pr-release` | testing, security, accessibility |
+| accessibility-specialist | `accessibility-audit` | (none - leaf) |
+| performance-specialist | `performance-audit` | (none - leaf) |
+| gtm-specialist | `gtm-performance-audit` | (none - leaf) |
+| security-specialist | `security-audit` | (none - leaf) |
+| testing-specialist | `test-generate`, `test-plan`, `test-coverage` | security, accessibility |
+| documentation-specialist | `docs-generate` | (none - leaf) |
+| live-audit-specialist | `live-site-audit` | performance, accessibility, security, code-quality |
+| code-quality-specialist | `quality-audit`, `quality-standards` | (none - leaf) |
+| structured-data-specialist | `structured-data-analyzer` | (none - leaf) |
+| drupal-pantheon-devops-specialist | `devops-setup` | (none - leaf) |
 
 ### Agent-to-Skill Mapping
 
@@ -149,14 +148,15 @@ Each agent uses specific skills for detailed "how-to" knowledge:
 
 Agent Skills are **model-invoked** capabilities—Claude decides when to use them based on your conversation context, without you needing to remember specific command names.
 
-### Three-Tier System Explained
+### Two-Tier System Explained
 
-| Feature | Slash Commands | Specialist Agents | Agent Skills |
-|---------|----------------|-------------------|--------------|
-| **Invocation** | User types `/command` | Commands spawn agents | Claude activates automatically |
-| **Use Case** | User-facing interface | Multi-step orchestration | Conversational assistance |
-| **Execution** | Spawns an agent | Coordinates workflow | Provides knowledge |
-| **Example** | `/pr-create PROJ-123` | workflow-specialist orchestrates PR creation | "I need to commit my changes" |
+| Feature | Specialist Agents | Agent Skills |
+|---------|-------------------|--------------|
+| **Invocation** | Spawned by skills | Claude activates automatically, or user invokes explicitly |
+| **Use Case** | Multi-step orchestration | Conversational assistance |
+| **Execution** | Coordinates workflow with tools | Provides knowledge and guidance |
+| **Example** | workflow-specialist orchestrates PR creation | "I need to commit my changes" → commit-message-generator activates |
+| **Explicit invoke** | — | `/pr-create PROJ-123` (Claude Code) or `@pr-create` (Codex) |
 
 ### Available Skills
 
@@ -663,23 +663,27 @@ Simply talk to Claude naturally—the skills activate automatically:
 
 No need to remember command names or syntax!
 
-### When to Use Slash Commands Instead
+### When to Invoke Skills Explicitly
 
-Use explicit slash commands when you want:
+Use explicit skill invocation when you want:
 
 **Full comprehensive analysis:**
-- `/audit-a11y` - Complete WCAG audit (not just one element)
-- `/audit-perf` - Full performance analysis with Lighthouse
-- `/audit-security` - Complete OWASP Top 10 scan
+- `audit-a11y` / `@audit-a11y` - Complete WCAG audit (not just one element)
+- `audit-perf` / `@audit-perf` - Full performance analysis with Lighthouse
+- `audit-security` / `@audit-security` - Complete OWASP Top 10 scan
 
 **Structured workflows:**
-- `/pr-create` - Create PR with full description
-- `/pr-review 123` - Review specific PR
-- `/pr-release` - Generate changelog and deployment notes
+- `pr-create` / `@pr-create` - Create PR with full description
+- `pr-review 123` / `@pr-review 123` - Review specific PR
+- `pr-release` / `@pr-release` - Generate changelog and deployment notes
 
 **Batch operations:**
-- `/test-generate` - Generate tests for entire module
-- `/docs-generate api` - Generate all API documentation
+- `test-generate` / `@test-generate` - Generate tests for entire module
+- `docs-generate api` / `@docs-generate api` - Generate all API documentation
+
+!!! tip "Syntax by platform"
+    Claude Code: prefix with `/` (e.g. `/pr-create PROJ-123`)
+    OpenAI Codex: prefix with `@` (e.g. `@pr-create PROJ-123`)
 
 ## Skill Activation Tips
 
@@ -721,23 +725,23 @@ Don't try to "game" the system—just describe what you need:
 
 ## Skills Reference Table
 
-| Skill | Triggers On | Best For | Related Command |
-|-------|-------------|----------|-----------------|
-| commit-message-generator | "commit", "staged" | Quick commits | `/pr-commit-msg` |
-| code-standards-checker | "standards", "style" | Code review | `/quality-standards` |
-| test-scaffolding | "need tests", "how to test" | Single class tests | `/test-generate` |
-| documentation-generator | "document", "API docs" | Quick docblocks | `/docs-generate` |
-| test-plan-generator | "test plan", "QA" | Test scenarios | `/test-plan` |
-| accessibility-checker | "accessible?", "WCAG" | Element checks | `/audit-a11y` |
-| performance-analyzer | "slow", "optimize" | Query optimization | `/audit-perf` |
-| gtm-performance-audit | "GTM", "tag manager", "marketing tags" | GTM tag analysis | `/audit-gtm` |
-| security-scanner | "secure?", "exploit" | Code security | `/audit-security` |
-| coverage-analyzer | "coverage", "untested" | Test gaps | `/test-coverage` |
-| structured-data-analyzer | "JSON-LD", "Schema.org", "structured data" | Schema.org checks | `/audit-structured-data` |
-| teamwork-task-creator | "create task", "make ticket" | Single task creation | `/teamwork create` |
-| teamwork-integrator | "PROJ-123", "status of" | Quick lookups | `/teamwork status` |
-| teamwork-exporter | "export to Teamwork" | Audit export | `/teamwork export` |
-| strategic-thinking | "should we do this?", "help me decide" | Decision making | None |
+| Skill | Triggers On | Best For | Explicit Invocation |
+|-------|-------------|----------|---------------------|
+| commit-message-generator | "commit", "staged" | Quick commits | `pr-commit-msg` |
+| code-standards-checker | "standards", "style" | Code review | `quality-standards` |
+| test-scaffolding | "need tests", "how to test" | Single class tests | `test-generate` |
+| documentation-generator | "document", "API docs" | Quick docblocks | `docs-generate` |
+| test-plan-generator | "test plan", "QA" | Test scenarios | `test-plan` |
+| accessibility-checker | "accessible?", "WCAG" | Element checks | `audit-a11y` |
+| performance-analyzer | "slow", "optimize" | Query optimization | `audit-perf` |
+| gtm-performance-audit | "GTM", "tag manager", "marketing tags" | GTM tag analysis | `audit-gtm` |
+| security-scanner | "secure?", "exploit" | Code security | `audit-security` |
+| coverage-analyzer | "coverage", "untested" | Test gaps | `test-coverage` |
+| structured-data-analyzer | "JSON-LD", "Schema.org", "structured data" | Schema.org checks | `audit-structured-data` |
+| teamwork-task-creator | "create task", "make ticket" | Single task creation | `teamwork create` |
+| teamwork-integrator | "PROJ-123", "status of" | Quick lookups | `teamwork status` |
+| teamwork-exporter | "export to Teamwork" | Audit export | `teamwork export` |
+| strategic-thinking | "should we do this?", "help me decide" | Decision making | — |
 
 ## Integration with Workflow
 
@@ -771,14 +775,15 @@ Agent Skills are project-level by default. To disable:
 ```
 
 **To prevent auto-activation:**
-Simply use explicit slash commands instead—Claude will respect your explicit command choice.
+Simply invoke the skill explicitly—Claude will respect your explicit choice.
 
 ## Learning More
 
 - **General Skills Documentation**: [Claude Code Skills](https://code.claude.com/docs/en/skills)
+- **Codex Plugin Documentation**: [OpenAI Codex Plugins](https://developers.openai.com/codex/plugins)
 - **Creating Custom Skills**: See [Contributing](contributing.md) guide
-- **Slash Commands Reference**: See [Commands Overview](commands/overview.md)
+- **Skills Reference**: See [Skills Overview](commands/overview.md)
 
 ---
 
-**Key Takeaway**: Agent Skills make CMS Cultivator proactive—Claude helps automatically when it sees you need assistance, while Slash Commands give you explicit control over comprehensive workflows.
+**Key Takeaway**: Agent Skills make CMS Cultivator proactive—Claude helps automatically when it sees you need assistance, while explicit invocation gives you direct control over comprehensive workflows.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,7 +10,7 @@ Thank you for your interest in contributing to CMS Cultivator! This document pro
 
 - Git
 - Python 3.x (for Zensical documentation)
-- Claude Code CLI (for testing commands)
+- Claude Code CLI or OpenAI Codex (for testing skills)
 - Basic knowledge of Markdown
 
 ### Setting Up Development Environment
@@ -29,6 +29,8 @@ Thank you for your interest in contributing to CMS Cultivator! This document pro
    ```
 
 4. **Test the plugin locally**:
+
+   **Claude Code:**
    ```bash
    # Link to Claude Code plugins directory, from WITHIN the cms-cultivator directory
    mkdir -p ~/.config/claude/plugins
@@ -36,56 +38,77 @@ Thank you for your interest in contributing to CMS Cultivator! This document pro
    claude plugins enable cms-cultivator
    ```
 
+   **OpenAI Codex:**
+   ```bash
+   # Link to Codex plugins directory, from WITHIN the cms-cultivator directory
+   mkdir -p ~/.codex/plugins
+   ln -s "$(pwd)" ~/.codex/plugins/cms-cultivator
+   # Then add ~/.agents/plugins/marketplace.json pointing to ~/.codex/plugins/cms-cultivator
+   # and restart Codex
+   ```
+
 ---
 
 ## Making Changes
 
-### Adding a New Command
+### Adding a New Skill
 
-#### 1. Create command file in `/commands/`
+#### 1. Create the skill directory and file
 
 ```bash
-touch commands/my-new-command.md
+mkdir -p skills/my-new-skill
+touch skills/my-new-skill/SKILL.md
 ```
 
-#### 2. Add frontmatter at the top
+#### 2. Add frontmatter and content
 
 ```yaml
 ---
-description: Brief description of what the command does
-argument-hint: [optional-arg]
-allowed-tools: Bash(git:*), Read, Glob, Grep, Write
+name: my-new-skill
+description: Automatically [action] when user [trigger phrase]. Invoke when user mentions "[term1]", "[term2]", or asks "[example question]".
 ---
 ```
 
-#### 3. Write command documentation
+Then write the skill content — workflow steps, examples, Drupal/WordPress-specific guidance.
 
-- Clear usage instructions
-- Example outputs
-- Drupal/WordPress-specific considerations
-- Integration with Kanopi tools (if applicable)
-
-#### 4. Test the command
+#### 3. Validate frontmatter
 
 ```bash
-# In Claude Code
-/my-new-command
+./scripts/validate-frontmatter.sh
+```
+
+#### 4. Test the skill locally
+
+**Claude Code:**
+```bash
+# Trigger via natural language
+"[describe scenario that should activate the skill]"
+
+# Or invoke explicitly
+/my-new-skill
+```
+
+**OpenAI Codex:**
+```bash
+# Trigger via natural language — same as Claude Code
+# Or invoke explicitly
+@my-new-skill
 ```
 
 #### 5. Add to documentation
 
-- Update `docs/commands/overview.md`
-- Add detailed guide if needed
+- Update `docs/commands/overview.md` with the new skill entry
+- Update `docs/agents-and-skills.md` if the skill spawns agents
 
-### Updating Existing Commands
+### Updating Existing Skills
 
-#### 1. Modify command file in `/commands/`
+#### 1. Modify the skill file in `skills/skill-name/SKILL.md`
 
 #### 2. Test thoroughly
 
-- Try different arguments
-- Test with both Drupal and WordPress projects
-- Verify Kanopi tool integration
+- Trigger via natural language
+- Try with both Drupal and WordPress projects
+- Verify Kanopi tool integration if applicable
 
 #### 3. Update documentation if behavior changed
 
@@ -134,9 +157,14 @@ zensical build --clean
 
 ### Frontmatter
 
-- `description`: Brief one-line description
-- `argument-hint`: Show optional arguments in square brackets
-- `allowed-tools`: List all tools the command can use
+**Skills** (`skills/*/SKILL.md`):
+- `name`: Skill identifier in kebab-case (must match directory name)
+- `description`: When to invoke, trigger phrases, and use cases
+
+**Agents** (`agents/*/AGENT.md`):
+- `name`: Agent name in kebab-case (must match directory name)
+- `description`: When and how to invoke this agent
+- `tools`: Available tools list
 
 ### Validating Frontmatter
 
@@ -169,11 +197,6 @@ argument-hint: "[operation] [args]"
 ```
 
 **Missing required fields** - Each file type has required fields:
-
-**Commands** (`commands/*.md`):
-- `description` - Brief one-line description
-- `allowed-tools` - Tools the command can use
-- `argument-hint` - Optional argument syntax (recommended)
 
 **Agents** (`agents/*/AGENT.md`):
 - `name` - Agent name (must match directory)

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 ![Maintained](https://img.shields.io/maintenance/yes/2025.svg)
 [![Documentation](https://img.shields.io/badge/docs-zensical-blue.svg)](https://kanopi.github.io/cms-cultivator/)
 
-**CMS Cultivator** is a comprehensive Claude Code plugin providing 38 Agent Skills for Drupal and WordPress development. Streamline PR workflows, ensure accessibility compliance, optimize performance, enhance security, and maintain documentation across your projects.
+**CMS Cultivator** is a plugin for Claude Code, Claude Desktop, and OpenAI Codex providing 38 Agent Skills for Drupal and WordPress development. Streamline PR workflows, ensure accessibility compliance, optimize performance, enhance security, and maintain documentation across your projects.
 
 ## ✨ Features
 
@@ -20,6 +20,7 @@
 - **🤖 Auto-Invoked** - Claude activates skills automatically during conversation
 - **💬 Natural Language** - No need to remember command names
 - **🎯 Context-Aware** - Activates when you need help
+- **🌐 Multi-Platform** - Works in Claude Code, Claude Desktop, and OpenAI Codex
 
 [Learn about Agents & Skills →](agents-and-skills.md)
 
@@ -132,7 +133,7 @@ CMS Cultivator integrates seamlessly with [Kanopi's DDEV add-ons](kanopi-tools/o
 
 ## 📋 Requirements
 
-- Claude Code CLI
+- Claude Code CLI **or** OpenAI Codex
 - Git
 - GitHub CLI (`gh`) for PR creation commands
 - Optional: Lighthouse, WebPageTest for performance analysis

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-CMS Cultivator can be installed globally for all projects or per-project for team collaboration.
+CMS Cultivator can be installed in Claude Code, Claude Desktop, or OpenAI Codex — globally for all projects or per-project for team collaboration.
 
 ---
 
@@ -8,14 +8,14 @@ CMS Cultivator can be installed globally for all projects or per-project for tea
 
 Before installing CMS Cultivator, ensure you have:
 
-- **Claude Code CLI** installed and configured
+- **Claude Code CLI** or **OpenAI Codex** installed and configured
 - **Git** for version control
 - **GitHub CLI** (`gh`) for PR creation commands (optional)
 - **DDEV** (for Kanopi projects) - [Install DDEV](https://ddev.readthedocs.io/en/stable/)
 
 ---
 
-## Installation Methods
+## Claude Code Installation
 
 !!! info "Global vs Project Installation"
     - **Methods 1-3** (Marketplace, Direct, Manual) install plugins **globally** - available in all your projects
@@ -178,21 +178,180 @@ Team members can override project settings in `.claude/settings.local.json` (not
 
 ---
 
+## OpenAI Codex Installation
+
+CMS Cultivator includes a `.codex-plugin/plugin.json` manifest and Codex-compatible TOML agent files. Install it via the Codex plugin system.
+
+### Codex Method 1: Via Marketplace (Recommended)
+
+Add the Kanopi marketplace and install from the Codex plugin browser.
+
+#### Step 1: Add the Kanopi Marketplace
+
+```bash
+codex plugin marketplace add kanopi/claude-toolbox
+```
+
+#### Step 2: Open the Plugin Browser
+
+```bash
+codex/plugins
+```
+
+Browse to CMS Cultivator, open its details, and select **Install plugin**.
+
+#### Step 3: Start a New Thread
+
+After installation, start a new Codex thread. Skills activate automatically from context, or invoke explicitly with `@skill-name` (e.g. `@pr-create`).
+
+#### Updating Via Marketplace
+
+```bash
+codex plugin marketplace upgrade
+```
+
+---
+
+### Codex Method 2: Personal Installation (Manual)
+
+Install directly to your personal Codex plugins directory. **Installs globally for all your projects.**
+
+#### Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/kanopi/cms-cultivator ~/.codex/plugins/cms-cultivator
+```
+
+#### Step 2: Create a Personal Marketplace File
+
+Create or update `~/.agents/plugins/marketplace.json`:
+
+```json
+{
+  "name": "kanopi-plugins",
+  "interface": {
+    "displayName": "Kanopi Plugins"
+  },
+  "plugins": [
+    {
+      "name": "cms-cultivator",
+      "source": {
+        "source": "local",
+        "path": "./cms-cultivator"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development"
+    }
+  ]
+}
+```
+
+#### Step 3: Restart Codex and Install
+
+Restart Codex, then open `codex/plugins`, find CMS Cultivator under the Kanopi Plugins marketplace, and install it.
+
+#### Updating Manual Installation
+
+```bash
+cd ~/.codex/plugins/cms-cultivator
+git pull origin main
+```
+
+Then restart Codex to pick up the changes.
+
+---
+
+### Codex Method 3: Repo-Scoped Installation
+
+Share the plugin with your team by configuring it in your project repository. **Installs per-project - only available in this specific project.**
+
+#### Step 1: Add the Plugin to Your Repo
+
+```bash
+git clone https://github.com/kanopi/cms-cultivator plugins/cms-cultivator
+```
+
+Or add it as a git submodule:
+
+```bash
+git submodule add https://github.com/kanopi/cms-cultivator plugins/cms-cultivator
+```
+
+#### Step 2: Create a Repo Marketplace File
+
+Create `$REPO_ROOT/.agents/plugins/marketplace.json`:
+
+```json
+{
+  "name": "project-plugins",
+  "plugins": [
+    {
+      "name": "cms-cultivator",
+      "source": {
+        "source": "local",
+        "path": "./plugins/cms-cultivator"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development"
+    }
+  ]
+}
+```
+
+#### Step 3: Commit to Repository
+
+```bash
+git add .agents/plugins/marketplace.json plugins/cms-cultivator
+git commit -m "Add CMS Cultivator plugin for Codex"
+git push
+```
+
+#### Team Member Setup
+
+When team members open the project in Codex, they run `codex/plugins`, find CMS Cultivator under the project marketplace, and install it.
+
+---
+
+### Disabling the Codex Plugin
+
+To keep the plugin installed but turn it off, edit `~/.codex/config.toml`:
+
+```toml
+[plugins."cms-cultivator@kanopi-plugins"]
+enabled = false
+```
+
+Then restart Codex.
+
+---
+
 ## Verifying Installation
 
 ### Test a Skill
 
-Open Claude Code in any project and try a skill by name or natural language:
+**Claude Code** — open in any project and try a skill by name or natural language:
 
 ```bash
 /quality-standards
 ```
 
-Or just say: "Does this follow Drupal coding standards?" — skills activate automatically in conversation.
+**Codex** — start a new thread and invoke explicitly or by natural language:
+
+```
+@quality-standards
+```
+
+Or just say: "Does this follow Drupal coding standards?" — skills activate automatically in conversation on both platforms.
 
 ### List Available Skills
 
-In Claude Code, type `/` to see all available skills. CMS Cultivator skills are organized by category:
+In Claude Code, type `/` to see all available skills. In Codex, type `@` to see installed plugin skills. CMS Cultivator skills are organized by category:
 
 - **PR Workflow**: `/pr-create`, `/pr-review`, `/pr-commit-msg`, `/pr-release`
 - **Accessibility**: `/audit-a11y` (with flexible modes)
@@ -371,12 +530,18 @@ cd ~/.claude/plugins/cms-cultivator
 git status
 ```
 
-### Project Settings Not Working
+### Project Settings Not Working (Claude Code)
 
 1. **Verify trust**: Ensure the project folder is trusted in Claude Code
 2. **Check JSON syntax**: Validate `.claude/settings.json` with a JSON linter
 3. **Restart Claude Code**: Close and reopen Claude Code after changing settings
 4. **Check marketplace availability**: Ensure `extraKnownMarketplaces` is configured correctly
+
+### Codex Plugin Not Appearing
+
+1. **Verify marketplace file**: Check that `marketplace.json` is valid JSON and `source.path` is correct
+2. **Restart Codex**: Codex reads marketplace files on startup
+3. **Check config**: Verify `~/.codex/config.toml` doesn't have the plugin set to `enabled = false`
 
 ---
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -4,7 +4,10 @@ Get started with CMS Cultivator in minutes! This guide covers the most common wo
 
 CMS Cultivator provides **two ways to work**:
 1. **Talk naturally** - Agent Skills automatically help when you need it
-2. **Use commands** - Explicit `/command` for full control
+2. **Use skills explicitly** - In Claude Code, use `/skill-name`. In Codex, use `@skill-name`.
+
+!!! note "Platform compatibility"
+    Natural language activation works the same on Claude Code, Claude Desktop, and OpenAI Codex. Explicit invocation syntax differs: Claude Code uses `/pr-create`, Codex uses `@pr-create`.
 
 ---
 

--- a/docs/reference/agent-skills-reference.md
+++ b/docs/reference/agent-skills-reference.md
@@ -2,7 +2,7 @@
 
 > **The core shift:** Slash commands required explicit invocation by the user. Skills are loaded automatically — Claude scans available skills and pulls in the right one based on task context. No `/command` syntax needed.
 
-Agent Skills launched October 2025 and replaced custom slash commands as the primary extensibility model for Claude Code plugins.
+Agent Skills launched October 2025 and replaced custom slash commands as the primary extensibility model for Claude Code plugins and OpenAI Codex plugins.
 
 ---
 
@@ -33,7 +33,9 @@ Claude can already do each individual step; the skill sequences them according t
 
 ---
 
-## Installing skills in Claude Code
+## Installing skills
+
+### Claude Code
 
 Skills in Claude Code are installed in one of two ways:
 
@@ -41,6 +43,12 @@ Skills in Claude Code are installed in one of two ways:
 - Manually by placing skill folders in `~/.claude/skills`
 
 Claude loads them automatically when relevant. Skills can be shared across a team through version control — just commit the skill folder.
+
+### OpenAI Codex
+
+Skills in Codex are distributed as part of plugins. Install a plugin via the Codex plugin browser (`codex/plugins`) or CLI (`codex plugin marketplace add owner/repo`), and its bundled skills become available automatically. Codex loads skills from the `skills/` directory specified in `.codex-plugin/plugin.json`.
+
+Skills activate by natural language context, or invoke them explicitly with `@skill-name` in the prompt.
 
 ---
 
@@ -65,7 +73,7 @@ One important implication: skills distributed inside a plugin use the same descr
 
 ## Testing and maintaining skills with skill-creator
 
-Skill-creator (available as a Claude Code plugin) adds software-development rigor to skill authoring — no code required.
+Skill-creator (available as a Claude Code plugin and for OpenAI Codex) adds software-development rigor to skill authoring — no code required.
 
 ### Evals
 


### PR DESCRIPTION
## Description

Teamwork Ticket(s): N/A
- [x] Was AI used in this pull request?

> As a developer using OpenAI Codex, I need clear installation instructions and accurate platform-specific documentation so I can install and use CMS Cultivator in Codex the same way Claude Code users can.

Updates the documentation site and README to reflect that CMS Cultivator supports Claude Code, Claude Desktop, **and** OpenAI Codex. Also corrects stale references from the v1.0.0 refactor (three-tier architecture, removed `commands/` directory) that were left in the docs.

## Acceptance Criteria

- [ ] `docs/installation.md` includes a full Codex installation section (marketplace CLI, personal, and repo-scoped methods)
- [ ] `docs/agents-and-skills.md` no longer references slash commands as a third tier or the removed `commands/` directory
- [ ] `docs/contributing.md` reflects the skills-based workflow for adding new features
- [ ] `docs/quick-start.md` explains `@skill-name` (Codex) vs `/skill-name` (Claude Code) invocation
- [ ] `docs/index.md` and `README.md` describe the plugin as multi-platform
- [ ] `zensical build --clean` passes with no errors

## Assumptions

- Codex installation commands are based on the official Codex plugin documentation
- The `kanopi/claude-toolbox` Codex marketplace was extended rather than creating a separate `kanopi/codex-toolbox` repo

## Steps to Validate

1. Review the updated `docs/installation.md` Codex section for accuracy
2. Run `zensical build --clean` — should complete with no errors
3. Run `zensical serve` and check Installation, Quick Start, Contributing, and Agents & Skills pages

## Affected URL

https://kanopi.github.io/cms-cultivator/

## Deploy Notes

Documentation only — no config imports, cache clears, or database updates needed. Deploys automatically to GitHub Pages on merge to `main`.