### PR TITLE
feat(skills): add four PM workflow skills (triage, meeting prep, heartbeat, QA)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cms-cultivator",
   "version": "1.1.0",
-  "description": "41 skills + 16 agents for Drupal/WordPress. Agents orchestrate comprehensive quality checks with parallel execution. Design-to-code workflows with browser validation. FRD generation, story point estimation, and CSV export for PM tools. Drupal.org contribution integration. Drupal/Pantheon DevOps automation.",
+  "description": "45 skills + 16 agents for Drupal/WordPress. Agents orchestrate comprehensive quality checks with parallel execution. Design-to-code workflows with browser validation. FRD generation, story point estimation, and CSV export for PM tools. PM workflows: client triage, meeting prep, project heartbeats, QA review. Drupal.org contribution integration. Drupal/Pantheon DevOps automation.",
   "author": {
     "name": "Kanopi Studios",
     "email": "code@kanopi.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cms-cultivator",
   "version": "1.1.0",
-  "description": "41 skills + 16 agents for Drupal and WordPress. Works in Claude Code, Claude Desktop, and OpenAI Codex.",
+  "description": "45 skills + 16 agents for Drupal and WordPress. Works in Claude Code, Claude Desktop, and OpenAI Codex.",
   "author": {
     "name": "Kanopi Studios",
     "email": "code@kanopi.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,21 +10,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - 2026-05-13
 
 ### Added
-- `frd-generator` skill: generate comprehensive Functional Requirements Documents with 10-section structure, requirement numbering (FR-XXX, TR-XXX, US-XXX, UI-XXX, DR-XXX, NFR-XXX, TS-XXX, RISK-XXX), and platform-specific subsections for Drupal recipes and WordPress block themes; ported from kanopi/cms-planner
-- `story-point-estimator` skill: Fibonacci-based story point estimation (1, 2, 3, 5, 8, 13, 21, 34+) with hour conversions, platform-specific adjustments, and velocity calculations; ported from kanopi/cms-planner
-- `csv-exporter` skill: convert FRD requirements into Teamwork-ready CSV backlog with three-level task hierarchy, story-point-to-hours conversion, and consistent tagging; ported from kanopi/cms-planner
+
+**Project planning skills (ported from kanopi/cms-planner):**
+
+- `frd-generator` skill: generate comprehensive Functional Requirements Documents with 10-section structure, requirement numbering (FR-XXX, TR-XXX, US-XXX, UI-XXX, DR-XXX, NFR-XXX, TS-XXX, RISK-XXX), and platform-specific subsections for Drupal recipes and WordPress block themes
+- `story-point-estimator` skill: Fibonacci-based story point estimation (1, 2, 3, 5, 8, 13, 21, 34+) with hour conversions, platform-specific adjustments, and velocity calculations
+- `csv-exporter` skill: convert FRD requirements into Teamwork-ready CSV backlog with three-level task hierarchy, story-point-to-hours conversion, and consistent tagging
 - `docs/commands/planning.md`: new documentation page covering the project planning workflow
 
+**PM workflow skills (authored by Andrew Nichols):**
+
+- `client-request-triage` skill: PM triage of a client Teamwork task — fetches the task, detects the platform, researches 1–3 solution options, and drafts a warm client-facing reply; pauses for PM confirmation before drafting. Flags bug reports for re-routing. (Teamwork MCP + web search)
+- `pm-meeting-prep` skill: prepare a PM for an upcoming client check-in by aggregating context from Teamwork (tasks + messages), Slack, Gmail, and Fathom into a structured briefing with talking points, blockers, and suggested next steps. Optionally generates a meeting agenda. (Teamwork + Slack + Gmail + Fathom MCPs)
+- `project-heartbeat` skill: draft a client-facing project status update message ready to post as a Teamwork reply. Finds the existing heartbeat message thread, reads the most recent reply to set the reporting window, then pulls completed tasks, project messages, Fathom summaries, and Slack channel activity. Written in a warm, progress-forward voice with budget/timeline placeholders for manual entry. (Teamwork + Slack + Fathom MCPs)
+- `qa-review` skill: full QA validation of a multidev environment from a Teamwork task. Reads the task and all comments, extracts the multidev URL, detects the platform, builds a validation plan (base checklist + dynamic steps), executes via CoWork browser automation, and produces a report with pass/fail per step, screenshots, internal notes, and a client-facing summary. (Teamwork MCP + CoWork)
+- `docs/commands/pm-workflows.md`: new documentation page covering all four PM skills with MCP setup notes
+
 ### Changed
-- Plugin description and skill count updated from 38 to 41 across `plugin.json`, `README.md`, `CLAUDE.md`, `skills/README.md`, `docs/index.md`, `zensical.toml`
+- Plugin description and skill count updated from 38 to 45 across `plugin.json`, `README.md`, `CLAUDE.md`, `skills/README.md`, `docs/index.md`, `zensical.toml`
 - Codex plugin version bumped to track the main plugin manifest
-- `tests/test-plugin.bats`: updated expected skill count (38 → 41) and agent count (17 → 16, removing the deleted `live-audit-specialist` references that were missed in v1.0.2)
+- `tests/test-plugin.bats`: updated expected skill count (38 → 45) and agent count (17 → 16, removing the deleted `live-audit-specialist` references that were missed in v1.0.2)
 - `frd-generator` SKILL.md: removed reference to `frd-specialist` agent (not migrated); added Companion Skills section linking to `story-point-estimator` and `csv-exporter`; expanded WordPress block theme subsection (was placeholder for v0.3.0)
-- `zensical.toml` nav: added Planning page to the Skills section
+- `zensical.toml` nav: added Planning and PM Workflows pages to the Skills section
 
 ### Migration Notes
 - The companion repository `kanopi/cms-planner` is now deprecated. Its three skills are available natively in CMS Cultivator with the same names and YAML frontmatter; no slash command exists (the v1.0 refactor removed `commands/` — invoke `frd-generator` conversationally instead).
 - The `frd-specialist` agent from cms-planner was intentionally not migrated; the three skills handle FRD generation directly without an orchestrating agent.
+- All four PM skills depend on MCP servers. Without the relevant MCPs configured, the skills cannot fetch tasks, messages, recordings, or browser sessions. See `docs/commands/pm-workflows.md` for setup details.
+- `project-heartbeat` is written in Andrew Nichols's personal voice; other PMs are encouraged to adjust signature and tone after the draft is generated.
+- `qa-review` requires CoWork browser automation to execute validation steps; without it the skill produces only the plan, not the report.
 
 ## [1.0.2] - 2026-04-29
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ cms-cultivator/
 │   ├── performance-specialist/
 │   ├── teamwork-specialist/
 │   └── ...                  # 16 total agents
-├── skills/                  # Agent Skill directories (41 total)
+├── skills/                  # Agent Skill directories (45 total)
 │   ├── commit-message-generator/
 │   ├── code-standards-checker/
 │   ├── test-scaffolding/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Maintained](https://img.shields.io/maintenance/yes/2026.svg)
 [![Documentation](https://img.shields.io/badge/docs-zensical-blue.svg)](https://kanopi.github.io/cms-cultivator/)
 
-Specialist agents and 41 auto-invoked skills for Drupal/WordPress development. Works in Claude Code, Claude Desktop, and OpenAI Codex.
+Specialist agents and 45 auto-invoked skills for Drupal/WordPress development. Works in Claude Code, Claude Desktop, and OpenAI Codex.
 
 **Full documentation:** [https://kanopi.github.io/cms-cultivator/](https://kanopi.github.io/cms-cultivator/)
 
@@ -96,6 +96,15 @@ Generate Functional Requirements Documents, estimate work, and export task backl
 - `story-point-estimator` - Fibonacci-based story point estimation with hour conversions
 - `csv-exporter` - Convert FRD requirements into Teamwork-ready CSV backlogs
 
+### PM Workflows
+Aggregate context from Teamwork, Slack, Gmail, and Fathom for client communication and QA review. Requires connected MCP servers.
+
+**Skills:**
+- `client-request-triage` - Review a client task, research solutions, and draft a reply (Teamwork + web search)
+- `pm-meeting-prep` - Aggregate context for an upcoming check-in (Teamwork + Slack + Gmail + Fathom)
+- `project-heartbeat` - Draft a client-facing project status update (Teamwork + Slack + Fathom)
+- `qa-review` - Full QA validation of a multidev environment from a Teamwork task (Teamwork + CoWork browser automation)
+
 **See [docs site](https://kanopi.github.io/cms-cultivator/) for complete skill reference and usage examples.**
 
 ---
@@ -120,7 +129,7 @@ Skills spawn specialized agents that orchestrate complex workflows:
 **Browser Validation:**
 - browser-validator-specialist
 
-### Agent Skills (41 total)
+### Agent Skills (45 total)
 
 Model-invoked skills that activate during conversation, across Claude Code, Claude Desktop, and OpenAI Codex:
 - accessibility-checker, security-scanner, performance-analyzer
@@ -132,6 +141,7 @@ Model-invoked skills that activate during conversation, across Claude Code, Clau
 - design-to-wp-block, design-to-drupal-paragraph, pr-create, pr-release
 - devops-setup, drupal-contribute, drupal-issue, drupal-mr, drupal-cleanup, wp-add-skills
 - frd-generator, story-point-estimator, csv-exporter
+- client-request-triage, pm-meeting-prep, project-heartbeat, qa-review
 
 ### How It Works
 

--- a/docs/agents-and-skills.md
+++ b/docs/agents-and-skills.md
@@ -754,6 +754,10 @@ Don't try to "game" the system—just describe what you need:
 | frd-generator | "FRD", "functional requirements document", "structure requirements" | Project planning | — |
 | story-point-estimator | "story points", "estimate this", "how long will this take?" | Sprint estimation | — |
 | csv-exporter | "export to CSV", "Teamwork backlog", "import to Teamwork" | Backlog generation | — |
+| client-request-triage | "triage this", "help me respond to this client", Teamwork link | Client request research + reply drafting (Teamwork MCP, web search) | — |
+| pm-meeting-prep | "prep me for my meeting", "check-in tomorrow" | Cross-source client meeting prep (Teamwork, Slack, Gmail, Fathom MCPs) | — |
+| project-heartbeat | "draft the heartbeat", "send a status update" | Client-facing status update messages (Teamwork, Slack, Fathom MCPs) | — |
+| qa-review | "QA this", "validate this multidev", "test the dev link" | Multidev validation report from a Teamwork task (Teamwork MCP, CoWork) | — |
 
 ## Integration with Workflow
 

--- a/docs/commands/pm-workflows.md
+++ b/docs/commands/pm-workflows.md
@@ -1,0 +1,157 @@
+# PM Workflows
+
+Four PM-focused skills that pull context from connected MCP servers (Teamwork, Slack, Gmail, Fathom, CoWork) to handle client communication, meeting preparation, status updates, and QA review.
+
+!!! warning "MCP servers required"
+    These skills rely on connected MCP servers to gather context. Without the relevant MCPs configured, they cannot fetch tasks, messages, recordings, or browser sessions. Set up the MCPs in your Claude Code or Claude Desktop configuration before invoking.
+
+---
+
+## Available Skills
+
+### client-request-triage
+
+**Purpose:** PM triage of a client Teamwork task or comment — researches solutions and drafts a client-facing reply before developer involvement.
+
+**Auto-invoked triggers:** "triage this", "look at this Teamwork task", "help me respond to this client", "draft a reply to this"
+
+**MCP dependencies:**
+
+- **Teamwork MCP** — fetches the task, description, and comments
+- **Web search** — researches 1–3 implementation options (Drupal modules, WordPress plugins, or general web patterns)
+
+**Workflow:**
+
+1. Fetches the task and identifies client vs. internal comments
+2. Detects the platform (Drupal/WordPress/general web)
+3. Researches relevant solution options
+4. Presents a summary with the recommended approach and pauses for PM confirmation
+5. Drafts a warm, professional client-facing reply — no estimates, no internal jargon
+
+**Special behavior:** If the task is clearly a bug report rather than a feature request or question, the skill stops and asks the PM how to proceed before continuing.
+
+---
+
+### pm-meeting-prep
+
+**Purpose:** Prepare a PM for an upcoming client check-in by aggregating context from across the project.
+
+**Auto-invoked triggers:** "prep me for my meeting", "check-in with [client] tomorrow", "meeting prep for [project]", "what do I need to know before my call?"
+
+**MCP dependencies:**
+
+- **Teamwork MCP** — recent tasks, status changes, project messages
+- **Slack MCP** — recent channel activity (channel searched by project name)
+- **Gmail MCP** — recent client email threads
+- **Fathom MCP** — summaries of recent recorded meetings
+
+**Output sections:**
+
+- Progress since last meeting
+- In-progress / ongoing work (with blockers flagged)
+- Talking points (3–6 items needing conversation)
+- New feature requests / scope discussions
+- Blockers and concerns
+- Suggested next steps
+
+After presenting the briefing, the skill optionally generates a formatted meeting agenda on request.
+
+---
+
+### project-heartbeat
+
+**Purpose:** Draft a client-facing project status update message ready to post as a Teamwork reply.
+
+**Auto-invoked triggers:** "draft the heartbeat", "time for a project update", "send a status update for [project]", "write the update for [project]"
+
+**MCP dependencies:**
+
+- **Teamwork MCP** — completed tasks, project messages, heartbeat message thread replies
+- **Slack MCP** — substantive project channel messages within the reporting window
+- **Fathom MCP** — summaries of meetings during the reporting window
+
+**Workflow:**
+
+1. Confirms the project (inferred from the named Claude Project when possible)
+2. Finds the existing heartbeat message thread and reads its most recent reply to determine the reporting window start
+3. Pulls activity from Teamwork, Slack, and Fathom in parallel for the window
+4. Drafts the update in Andrew's established voice: warm, progress-forward, transparent
+5. Leaves explicit placeholders for budget and timeline (these are not pulled automatically)
+
+!!! note "Voice"
+    `project-heartbeat` is written in Andrew Nichols's personal voice (warm/collegial opener, narrative paragraphs, signed "Cheers, Andrew"). Other PMs are welcome to use the skill — adjust the signature and tone after the draft is generated to match your own voice.
+
+---
+
+### qa-review
+
+**Purpose:** Full QA validation of a multidev environment from a Teamwork task — reads context, builds a validation plan, executes it in a browser, and produces a structured report.
+
+**Auto-invoked triggers:** "QA this", "validate this multidev", "test the dev link", "run QA on [task]", "review this ticket"
+
+**MCP dependencies:**
+
+- **Teamwork MCP** — fetches the task, description, all comments, and the multidev URL
+- **CoWork browser automation** — navigates the multidev environment, executes validation steps, captures screenshots
+
+**Workflow:**
+
+1. Reads the Teamwork task and all comments; extracts the multidev URL (Pantheon, WP Engine, Kinsta, etc.)
+2. Detects the platform (Drupal vs. WordPress) from task content, URLs, or plugin/module names
+3. Builds a validation plan: base checklist + dynamic steps based on the task type (update, bug fix, new feature)
+4. Executes each step via CoWork, capturing screenshots and pass/fail/warning results
+5. Produces a structured report: overall result, step-by-step results table, issues with screenshots, internal notes, and a client-facing summary
+
+!!! warning "CoWork dependency"
+    `qa-review` cannot execute validation steps without CoWork browser automation. Without it, the skill will produce the validation plan but not the report.
+
+---
+
+## When to Use These Skills
+
+### Use `client-request-triage` when:
+
+- A client posts a new task or comment requesting a feature or asking a question
+- You need to understand what's being asked and what the realistic options are
+- You want a polished reply ready to send back before looping in a developer
+
+### Use `pm-meeting-prep` when:
+
+- A scheduled client check-in is coming up
+- You need a single briefing that pulls from every project context source
+- You want a meeting agenda template based on real recent activity
+
+### Use `project-heartbeat` when:
+
+- It's time to send a recurring project status update
+- You have a long-running "Project Update" message thread in Teamwork and need to draft the next reply
+- You want a draft that reflects actual completed work and meeting outcomes without manual aggregation
+
+### Use `qa-review` when:
+
+- A developer hands off a task on a multidev environment and you need to validate before merging
+- You want a structured report with both internal notes and a client-facing summary
+- Browser automation is available (CoWork connected)
+
+---
+
+## MCP Setup Notes
+
+Configure these MCPs in your Claude Code or Claude Desktop client to use the PM skills:
+
+| Skill | Required MCPs |
+|-------|----------------|
+| `client-request-triage` | Teamwork + web search |
+| `pm-meeting-prep` | Teamwork + Slack + Gmail + Fathom |
+| `project-heartbeat` | Teamwork + Slack + Fathom |
+| `qa-review` | Teamwork + CoWork browser automation |
+
+If a non-blocking source returns no results (e.g., Fathom has no recent meetings), the skills note it and continue with the remaining sources rather than failing.
+
+---
+
+## Next Steps
+
+- **[Agents & Skills](../agents-and-skills.md)** — How skills auto-activate from natural language
+- **[Project Management Skills](project-management.md)** — Teamwork task creation and audit export
+- **[Project Planning](planning.md)** — FRD, story point, and CSV export skills

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,11 +3,11 @@
 ![Maintained](https://img.shields.io/maintenance/yes/2025.svg)
 [![Documentation](https://img.shields.io/badge/docs-zensical-blue.svg)](https://kanopi.github.io/cms-cultivator/)
 
-**CMS Cultivator** is a plugin for Claude Code, Claude Desktop, and OpenAI Codex providing 41 Agent Skills for Drupal and WordPress development. Streamline PR workflows, ensure accessibility compliance, optimize performance, enhance security, plan projects, and maintain documentation.
+**CMS Cultivator** is a plugin for Claude Code, Claude Desktop, and OpenAI Codex providing 45 Agent Skills for Drupal and WordPress development. Streamline PR workflows, ensure accessibility compliance, optimize performance, enhance security, plan projects, and maintain documentation.
 
 ## ✨ Features
 
-### 41 Agent Skills
+### 45 Agent Skills
 - **🔄 PR Workflow** - Streamline pull requests from commit to deployment
 - **♿ Accessibility** - Ensure WCAG 2.1 Level AA compliance
 - **⚡ Performance** - Optimize Core Web Vitals and page speed
@@ -18,6 +18,7 @@
 - **🧪 Testing** - Create tests and analyze coverage
 - **📊 Code Quality** - Maintain standards and reduce technical debt
 - **📋 Project Planning** - Generate FRDs, estimate story points, and export Teamwork backlogs
+- **🗂 PM Workflows** - Client request triage, meeting prep, project heartbeats, and full QA review (requires MCP servers)
 - **🤖 Auto-Invoked** - Claude activates skills automatically during conversation
 - **💬 Natural Language** - No need to remember command names
 - **🎯 Context-Aware** - Activates when you need help
@@ -157,5 +158,5 @@ MIT License - see LICENSE file for details.
 
 1. **[Install the plugin](installation.md)** - Get started in minutes
 2. **[Try Quick Start examples](quick-start.md)** - Learn common workflows
-3. **[Explore Skills](commands/overview.md)** - Discover all 41 available skills
+3. **[Explore Skills](commands/overview.md)** - Discover all 45 available skills
 4. **[Integrate Kanopi Tools](kanopi-tools/overview.md)** - Use with DDEV add-ons

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,6 @@
 # CMS Cultivator Agent Skills
 
-This directory contains 41 Agent Skills that Claude automatically invokes during conversation when contextually appropriate.
+This directory contains 45 Agent Skills that Claude automatically invokes during conversation when contextually appropriate.
 
 ## What Are Agent Skills?
 
@@ -381,6 +381,30 @@ Detailed instructions for Claude on how to execute this skill...
 
 **Triggers**: "export to CSV", "Teamwork backlog", "project backlog file", "import to Teamwork"
 **Purpose**: Convert FRD requirements into Teamwork-ready CSV backlog with task hierarchy (epic/story/task prefixes), priority mapping, story-point-to-hours conversion, and consistent tagging.
+
+### 42. client-request-triage
+
+**Triggers**: "triage this", "look at this task", "help me respond to this client", Teamwork task or comment link provided
+**Purpose**: Fetch a client Teamwork task, detect the platform (Drupal/WordPress/general), research 1–3 solution options, and draft a warm client-facing reply. Pauses for PM confirmation before drafting. Flags bug reports for re-routing.
+**MCP dependencies**: Teamwork, web search
+
+### 43. pm-meeting-prep
+
+**Triggers**: "prep me for my meeting", "check-in with [client] tomorrow", "meeting prep for [project]"
+**Purpose**: Aggregate context from Teamwork (tasks + messages), Gmail, Slack, and Fathom recordings into a structured client check-in briefing with talking points, blockers, and suggested next steps. Optionally generates a formatted meeting agenda.
+**MCP dependencies**: Teamwork, Slack, Gmail, Fathom
+
+### 44. project-heartbeat
+
+**Triggers**: "time for a project update", "draft the heartbeat", "write up the update for [project]", "send a status update"
+**Purpose**: Generate a client-facing project status update message for posting to a Teamwork message thread. Pulls completed tasks, Teamwork messages, Fathom meeting summaries, and Slack channel activity since the last heartbeat reply. Drafted in a warm, progress-forward voice with budget and timeline placeholder sections.
+**MCP dependencies**: Teamwork, Slack, Fathom
+
+### 45. qa-review
+
+**Triggers**: "QA this", "validate this multidev", "test the dev link", "run QA on this task", Teamwork task with multidev URL
+**Purpose**: Full QA review of a Teamwork task: reads task and all comments, extracts the multidev URL, detects the platform (Drupal/WordPress), builds a dynamic validation plan (base checklist + task-specific steps), executes the plan via CoWork browser automation, and produces a report with pass/fail per step, screenshots, internal notes, and a client-facing summary.
+**MCP dependencies**: Teamwork, CoWork browser automation
 
 ## Adding New Skills
 

--- a/skills/client-request-triage/SKILL.md
+++ b/skills/client-request-triage/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: client-request-triage
+description: PM triage skill for reviewing client-submitted Teamwork tasks or comments (feature requests, general questions). Given a Teamwork link, fetches the task, detects the platform (Drupal/WordPress/general web), researches potential solutions, and drafts a warm client-facing reply. Use this skill whenever a user shares a Teamwork task or comment link and wants to understand the client's request, explore implementation options, or draft a response — even if they just say "can you look at this task?" or "help me respond to this client". Also triggers for phrases like "triage this", "review this client request", "what should we tell the client", or "help me draft a reply to this Teamwork task". No estimates are included at this stage.
+---
+
+# Client Request Triage
+
+A PM triage skill that takes a client Teamwork task or comment, researches solutions, and helps draft a clear client-facing reply — before any developer involvement is needed.
+
+---
+
+## Workflow
+
+### Step 1: Fetch the Task
+
+Use the Teamwork MCP to retrieve the task from the provided link. Extract:
+- Task title and full description
+- All comments (identify which are from the client vs. internal team)
+- Project name and any tags or metadata
+- Any linked tasks or context
+
+If the link points to a specific comment, focus on that comment but read the full task thread for context.
+
+---
+
+### Step 2: Detect the Platform
+
+Infer the platform from the project name, task language, module/plugin mentions, or any other context clues:
+
+- **Drupal** — mentions of content types, views, paragraphs, modules, Pantheon, etc.
+- **WordPress** — mentions of plugins, Gutenberg, WooCommerce, themes, etc.
+- **General web** — if unclear or platform-agnostic, treat as general web best practices
+
+If the platform is ambiguous, note it and proceed with general web guidance — don't ask the user unless truly impossible to infer.
+
+---
+
+### Step 3: Understand and Summarize the Request
+
+Distill the client's ask into plain language. Cover:
+- What they are asking for
+- The problem they are trying to solve (if inferable)
+- Any constraints or preferences they mentioned
+- Any ambiguities or missing information that would be good to clarify
+
+---
+
+### Step 4: Research Solutions
+
+Use web search to research relevant options. Look for:
+- Drupal modules (drupal.org/project/...) or WordPress plugins (wordpress.org/plugins/...) that address the need
+- Established web patterns or approaches for solving this type of problem
+- Any known limitations, gotchas, or trade-offs worth flagging
+
+Find **1 to 3 options** based on what makes sense for the request:
+- If there's one obvious best approach, present just that
+- If there are meaningfully different ways to solve it (e.g. simpler vs. more flexible), present 2–3
+- Describe the options naturally — no "Simple / Moderate / Complex" labels. Let the description convey the trade-offs
+- Lead with what you'd recommend and why, briefly
+
+---
+
+### Step 5: Present Summary and Pause
+
+Before drafting anything, present the following to the PM and **wait for confirmation**:
+
+```
+**Request Summary**
+[Plain-language summary of what the client is asking]
+
+**Potential Approaches**
+[1–3 options with natural descriptions and trade-offs]
+
+**Recommendation**
+[Which approach you'd suggest and a brief reason]
+
+**Clarifying Questions (if any)**
+[Any gaps in the request that might be worth asking the client about]
+
+---
+Ready to draft the client reply? Let me know if anything looks off first.
+```
+
+Do not proceed to drafting until the PM confirms or provides adjustments.
+
+---
+
+### Step 6: Draft the Client-Facing Reply
+
+Once confirmed, draft a reply following these guidelines:
+
+**Tone:** Professional, warm, and clear. Match the tone of the person using the skill. When in doubt, use the default style: friendly and direct, not overly formal, with a helpful closing.
+
+**Structure:**
+1. Acknowledge the request and show you understood it
+2. Summarize the recommended approach(es) in plain language the client can follow
+3. If multiple options, explain them naturally without jargon
+4. End with a clear next step or call to action (e.g. "let us know if this aligns with your vision" or "happy to discuss further before we move ahead")
+5. Close warmly
+
+**Rules:**
+- No estimates or timelines
+- No internal jargon (no "sprint", "ticket", "dev", "module machine name", etc.)
+- Keep it concise — clients should be able to read it in under 2 minutes
+- The draft should be paste-ready (no placeholders like [NAME] unless truly needed)
+
+Present the draft in a clearly labelled block so it's easy to copy.
+
+---
+
+## Notes
+
+- This skill is for **initial PM triage only** — the goal is to start the conversation with the client before looping in a developer
+- If the task is clearly a bug report rather than a feature request or question, **stop and flag it to the PM** before proceeding. Say something like: "This looks like a bug report rather than a feature request or question — this skill is optimized for triage of feature requests and general questions. Would you like me to continue anyway, or handle this differently?" Do not proceed with the research and drafting workflow until the PM confirms.
+- If the client's request is very vague, the clarifying questions in Step 5 become especially important — surface those clearly

--- a/skills/pm-meeting-prep/SKILL.md
+++ b/skills/pm-meeting-prep/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: pm-meeting-prep
+description: >
+  Quickly prepare a PM for an upcoming client check-in by pulling together context from Teamwork (tasks + messages), Gmail, Slack, and Fathom meeting recordings. Produces a structured briefing with talking points, ticket progress, new feature requests, and suggested next steps — then optionally generates a formatted agenda.
+
+  Use this skill whenever the user says things like:
+  - "prep me for my meeting with [client]"
+  - "I have a check-in with [project] tomorrow, help me prep"
+  - "what do I need to know before my call with [client]?"
+  - "get me ready for [project name] meeting"
+  - "meeting prep for [project]"
+
+  Always trigger this skill when meeting preparation is the goal, even if the user doesn't say "skill" or "prep" explicitly. If the user mentions a client name or project name alongside a meeting, check-in, or call — use this skill.
+---
+
+# PM Meeting Prep
+
+A skill for preparing a PM for an upcoming client check-in. It aggregates context from Teamwork, Gmail, Slack, and Fathom, then produces a clear briefing.
+
+---
+
+## Step 1: Gather Inputs
+
+If not already provided, ask for:
+
+1. **Project name** — used to find the Teamwork project and Slack channel
+2. **Time range** — "How far back should I look? (e.g. last 7 days, last 2 weeks, since last meeting)" — default to 2 weeks if not specified
+
+Do not ask for the Slack channel name upfront — search for it using the project name first (see Step 3).
+
+---
+
+## Step 2: Pull Teamwork Data
+
+Use the Teamwork MCP to:
+
+1. **Find the project** — search by name using `twprojects-list_projects` or `twprojects-search`
+2. **List recent tasks** — use `twprojects-list_tasks` filtered to the project, looking for:
+   - Tasks updated or completed within the time range
+   - Tasks that are overdue or blocked
+   - Any tasks with recent comments
+3. **List recent messages** — use `twprojects-list_messages` for the project to find any updates, discussions, or announcements posted in the time range
+4. **Note task statuses** — capture what's in progress, what's done, what's stuck
+
+---
+
+## Step 3: Pull Slack Messages
+
+1. **Search for the channel** — use `slack_search_channels` with the project name as the query
+   - If a clear match is found, use it
+   - If multiple matches or no clear match, ask the user: "I found these channels: [list]. Which one should I use?"
+2. **Read recent messages** — use `slack_read_channel` for the matched channel, scoped to the time range
+3. **Look for** — client questions, action items mentioned in chat, any issues raised, tone/sentiment shifts
+
+---
+
+## Step 4: Pull Gmail Threads
+
+Use Gmail MCP to search for recent email threads related to the project/client:
+
+1. Search using `search_threads` with the project or client name as the query, filtered to the time range
+2. Read relevant threads using `get_thread`
+3. **Look for** — outstanding questions from the client, action items promised by the team, any concerns or escalations, feedback on deliverables
+
+---
+
+## Step 5: Pull Fathom Meeting Recordings
+
+Use Fathom MCP to find any recent recorded meetings related to the project:
+
+1. Use `search_meetings` with the project/client name
+2. Filter to meetings within the time range (or slightly before, to capture the last check-in)
+3. For any matches, use `get_meeting_summary` to pull the AI summary — no need to pull the full transcript unless the summary is sparse
+4. **Look for** — unresolved action items from the last call, topics that were flagged for follow-up, any commitments made by either side
+
+---
+
+## Step 6: Synthesize and Present the Briefing
+
+Present the output in this format in chat — clean, scannable, PM-friendly:
+
+---
+
+### 📋 Meeting Prep: [Project Name]
+**Period reviewed:** [date range]
+**Sources checked:** Teamwork · Slack · Gmail · Fathom
+
+---
+
+#### ✅ Progress Since Last Meeting
+A bullet list of what has been completed or meaningfully advanced. Be specific — reference ticket names or task descriptions where relevant.
+
+#### 🔄 In Progress / Ongoing
+Tasks or items actively being worked on. Flag anything that's behind schedule or blocked.
+
+#### 💬 Talking Points
+The 3–6 most important things to cover in the meeting. These should be actionable and client-relevant — not just status updates, but things that require a conversation (decisions needed, feedback requested, concerns raised).
+
+#### 🆕 New Feature Requests / Scope Discussions
+Any requests that came up in Slack, email, or Teamwork messages that haven't been formally scoped or ticketed. Flag these clearly as items that may require estimation or separate discussion.
+
+#### ⚠️ Blockers or Concerns
+Anything flagged as blocked, overdue, or unresolved — including outstanding client questions that haven't been answered.
+
+#### 🔜 Suggested Next Steps
+3–5 concrete next steps the PM should be prepared to discuss or confirm in the meeting.
+
+---
+
+After presenting the briefing, ask:
+
+> "Would you like me to turn this into a formatted meeting agenda you could share or use as a template?"
+
+If yes, see **Agenda Format** below.
+
+---
+
+## Agenda Format (on request)
+
+If the user wants a formatted agenda, produce the following in a clean copyable block:
+
+```
+Meeting Agenda — [Project Name]
+Date: [date]
+
+1. Quick wins & progress update (~5 min)
+   - [bullet from Progress section]
+
+2. In-progress items & blockers (~10 min)
+   - [bullet from In Progress / Blockers]
+
+3. Open discussion topics (~10 min)
+   - [bullet from Talking Points]
+
+4. New requests / scope items (~5 min)
+   - [bullet from Feature Requests]
+
+5. Next steps & action items (~5 min)
+   - [bullet from Next Steps]
+```
+
+---
+
+## Tips & Edge Cases
+
+- **If Fathom has no results** — note it in the briefing ("No recent Fathom recordings found") and continue without it
+- **If Slack channel is ambiguous** — ask before proceeding, don't guess
+- **If the time range yields sparse results** — mention this and offer to expand the range
+- **If the project can't be found in Teamwork** — ask the user to confirm the exact project name
+- **Tone** — the briefing should be direct and PM-readable. No filler. Assume the reader is busy.

--- a/skills/project-heartbeat/SKILL.md
+++ b/skills/project-heartbeat/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: project-heartbeat
+description: >
+  Generate a client-facing project heartbeat / status update message for a Kanopi project,
+  ready to be posted as a Teamwork message. Use this skill whenever the user asks to write,
+  draft, generate, or send a project update, heartbeat, status update, or progress report
+  to a client. Also triggers when the user says things like "time for a project update",
+  "draft the heartbeat", "write up the update for [project]", or "it's been two weeks,
+  let's send an update". Always use this skill — even if the user doesn't say "heartbeat"
+  — whenever the intent is to summarise recent project activity for a client audience.
+---
+
+# Project Heartbeat Skill
+
+Generate a polished, client-facing Teamwork project update message by pulling recent
+activity from Teamwork and Fathom, then drafting it in Andrew's established voice and format.
+
+---
+
+## Step 1 — Confirm the Project
+
+If the conversation is happening inside a named Claude Project, infer the project from that
+context and confirm with the user before proceeding:
+
+> "I'll draft a heartbeat for **[Project Name]** — is that right?"
+
+If the project is ambiguous or not obvious, ask directly:
+
+> "Which Teamwork project should I pull the heartbeat for?"
+
+Once confirmed, look up the project in Teamwork to get its `project_id`.
+
+---
+
+## Step 2 — Find the Last Heartbeat & Set the Reporting Window
+
+> ⚠️ **Critical:** Heartbeat updates are posted as **replies to a single long-running message thread**, not as separate messages. The parent message may have been created months ago — its date is irrelevant. You must look at the **replies**, not the parent.
+
+Using the Teamwork MCP:
+
+1. Use `list_messages` to find the project's heartbeat/update message thread (typically titled "Project Update" or similar).
+2. Once you have the message ID, use `list_message_replies` with that message ID to fetch all replies.
+3. Find the **most recent reply** by sorting replies by `createdAt` descending and taking the first result.
+4. The **reporting window start** is the `createdAt` of that most recent reply.
+
+**Do not use the parent message's `createdAt` under any circumstances.** The parent is just the thread container — the actual updates live in the replies.
+
+Before moving to Step 3, confirm the window with the user:
+
+> "The last heartbeat reply was posted on **[createdAt of most recent reply]**. I'll pull activity from then through today ([TODAY]). Does that look right?"
+
+Wait for confirmation before proceeding.
+
+- **Reporting window start**: `createdAt` of the most recent reply in the heartbeat thread
+- **Reporting window end**: today's date
+
+If the message thread has no replies at all, fall back to the parent message's `createdAt` and note this is effectively the first update since the thread was opened.
+
+---
+
+## Step 3 — Gather Data (run these in parallel where possible)
+
+> Use **Teamwork MCP** tools for all Teamwork data (projects, tasks, messages).
+> Use **Fathom MCP** tools for all meeting data.
+
+### 3a. Teamwork — Completed Tasks
+Use the Teamwork MCP to pull all tasks completed within the reporting window for the project.
+Group them loosely by theme or tasklist (e.g. Discovery, Technical, UX, Content).
+Focus on tasks that would be meaningful to a client — skip purely internal admin tasks.
+
+### 3b. Teamwork — Recent Messages
+Use the Teamwork MCP to pull project messages from the reporting window. Scan for:
+- Key decisions made
+- Items shared with the client
+- Open questions or action items flagged
+- Any blockers or risks mentioned
+
+### 3c. Fathom — Recent Meeting Summaries
+Use the Fathom MCP to search for meetings associated with this project during the reporting window.
+From each meeting, extract:
+- Key topics discussed
+- Decisions or outcomes
+- Action items (especially ones assigned to Kanopi)
+- Any blockers or risks raised
+
+### 3d. Slack — Project Channel
+Use the Slack MCP to find and read the project's Slack channel. The channel name is typically
+just the client name (e.g. `#smalley` for the Smalley project, `#acme` for an Acme project).
+
+1. Use `slack_search_channels` to find the channel by the client/project name if the channel ID isn't already known.
+2. Use `slack_read_channel` to read messages within the reporting window. Filter to messages
+   that fall between the reporting window start date and today.
+3. Scan the messages for:
+   - Key decisions or agreements made
+   - Items flagged as blockers or risks
+   - Action items assigned to either side
+   - Any context that didn't make it into Teamwork or meetings
+4. Ignore emoji reactions, bot messages, and purely social exchanges — focus on substantive
+   project communication only.
+
+If no matching channel is found, skip this step silently and proceed with the other sources.
+
+### 3e. SOW / Project Context (if available)
+If a Statement of Work or project brief has been added to this Claude Project as context,
+use it to:
+- Understand the project phases and deliverables
+- Correctly label budget line items
+- Frame "Looking Ahead" items against upcoming deliverables
+
+### 3f. Budget
+Budget data is **not pulled automatically** — leave a clear placeholder in the draft:
+
+```
+[BUDGET TABLE — Please fill in manually:
+ Reporting Period: Thru [DATE]
+ Total Hours Used: [X]
+ Table: Item | Hours Allocated | Hours Used | Hours Remaining | Notes]
+```
+
+---
+
+## Step 4 — Draft the Message
+
+Use the structure and tone from the reference examples below. Write in Andrew's voice:
+warm, professional, client-focused, concise. Avoid internal jargon. Do not mention
+specific team member names unless they were already shared with the client.
+
+### Message Structure
+
+```
+@[Client contacts]
+
+[Opening paragraph — 2–4 sentences]
+Warm opener referencing where the project is at. High-level summary of the period's
+momentum. Keep it energetic but grounded.
+
+[1–2 body paragraphs]
+Narrative summary of what happened. Weave together completed work, meeting outcomes,
+and key decisions. Don't just list — tell the story of progress.
+
+---
+
+### Budget
+Reporting Period: Thru [DATE]
+
+Total Hours Used: [X]
+
+[BUDGET TABLE PLACEHOLDER]
+
+---
+
+### Timeline
+- Projected Completion Date: [from SOW or previous update]
+
+---
+
+### Recent Highlights
+- [Bullet per meaningful completed item, decision, or milestone]
+- Keep to 6–10 bullets max
+- Client-facing language only
+
+---
+
+### Looking Ahead
+- [Bullet per upcoming task, next step, or open item needing client input]
+- Flag any items requiring client action clearly
+
+---
+
+Please let me know if there are any items we may have missed or if there is anything
+you would like to discuss in additional detail.
+
+Cheers,
+
+Andrew
+```
+
+---
+
+## Step 5 — Present the Draft
+
+Show the full draft in the chat as a clean, readable message (not HTML).
+Below the draft, add a short **"Sources Used"** summary — e.g.:
+
+> **Sources used:** 12 completed tasks (Apr 22–May 7), 3 Fathom meeting summaries
+> (Apr 23, Apr 28, May 1), 4 Teamwork messages, 18 Slack messages (#smalley). Budget table left blank for manual entry.
+
+Then ask:
+> "Want me to adjust the tone, add/remove anything, or post this to Teamwork once you're happy?"
+
+---
+
+## Tone & Voice Reference
+
+Based on Andrew's existing updates, the tone should be:
+
+- **Warm and collegial** — "Hope you're both doing well!", "It's been a pleasure…"
+- **Progress-forward** — emphasise momentum, not just task completion
+- **Transparent** — flag blockers or redirected scope clearly and without alarm
+- **Action-oriented** — "Looking Ahead" should feel like a confident plan, not a vague list
+- **Concise** — paragraphs are 3–5 sentences; bullets are tight (one idea each)
+
+Avoid:
+- Internal team names or Slack-style shorthand
+- Overly technical language unless the client is technical
+- Passive voice ("it was decided" → "we decided")
+- Filler phrases like "as per", "circling back", "per my last message"
+
+---
+
+## Edge Cases
+
+- **No completed tasks in the window**: Note that the team has been in planning/prep mode
+  and highlight meeting outcomes and upcoming work instead.
+- **No Fathom meetings found**: Proceed with Teamwork data only; don't mention the absence.
+- **Multiple projects matched**: Ask the user to clarify before proceeding.
+- **First update ever**: Skip the "since our last update" framing; open with a "first formal
+  project update" tone (as seen in the reference message).

--- a/skills/qa-review/SKILL.md
+++ b/skills/qa-review/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: qa-review
+description: >
+  Perform a full QA review of a Teamwork task by reading the task and all its comments for context,
+  extracting the multi-dev URL, generating dynamic validation steps tailored to the task type, and
+  using CoWork browser automation to execute those steps on the multi-dev environment. Produces a
+  structured validation report with pass/fail per step, screenshots, internal notes, and a
+  client-facing summary — all shown in chat.
+
+  Use this skill whenever the user asks to QA, test, validate, or review a Teamwork task or
+  multi-dev environment — even if they just say "can you QA this?" or paste a Teamwork link.
+  Also triggers for phrases like "run QA on", "check the multi-dev", "validate this task",
+  "test the dev link", or "review the ticket". Works across Drupal/CMS updates, WordPress/plugin
+  updates, bug fixes, new feature development, and general web development tasks.
+---
+
+# QA Review Skill
+
+Performs end-to-end QA on a Teamwork task: reads context, extracts the multi-dev URL, builds
+a validation plan, executes it via CoWork browser automation, and produces a full report.
+
+---
+
+## Step 1 — Read the Teamwork Task
+
+Use the Teamwork MCP to fetch:
+- The full task description
+- **All comments** on the task (not just the most recent)
+
+Extract and summarize:
+- **What was done** (the change, fix, or feature)
+- **Task type** (Drupal/CMS update, WordPress/plugin update, bug fix, new feature, general web dev)
+- **Platform** — detect whether this is a **WordPress** or **Drupal** site based on task content, comments, URLs, or plugin/module names mentioned. If unclear, infer from the URL (e.g. WP Engine = likely WordPress; Pantheon = could be either — look for Drupal module names vs. WP plugin names). If still ambiguous, ask the user before proceeding.
+- **Any specific areas to test** mentioned by the developer
+- **Known issues or caveats** noted in the comments
+- **The multi-dev URL** — scan all comments and the description; it may be labeled "Multi-Dev:", "multidev:", "staging:", or just be a bare URL (e.g. *.pantheonsite.io, *.wpengine.com, *.kinsta.cloud, *.pantheon.io, or similar dev/staging domains). If multiple URLs are found, list them and ask the user which to test unless one is clearly labeled as the primary environment.
+
+If no URL is found, stop and ask the user to provide it before continuing.
+
+---
+
+## Step 2 — Build the Validation Plan
+
+Combine a **base checklist** with **dynamic steps** derived from the task context and detected platform.
+
+### Base Checklist (always included, all platforms)
+
+- [ ] Site loads without errors (no PHP errors, white screen, or 500s)
+- [ ] Homepage renders correctly
+- [ ] Navigation works (primary menu, links resolve)
+- [ ] No JavaScript console errors on key pages
+- [ ] Admin/backend is accessible (if applicable)
+- [ ] Forms render and appear functional
+- [ ] Mobile responsiveness — check at least one key page at mobile width
+
+---
+
+### Dynamic Steps (generated from task context)
+
+Select steps from the relevant platform section below based on the detected platform and task type.
+
+---
+
+#### Drupal-Specific Steps
+
+**Drupal Core / Module Update:**
+- Verify the specific modules or core version mentioned are active (check /admin/modules)
+- Test any functionality the updated modules affect (e.g. cloning, access checks, field display, views)
+- Check content editing experience for relevant content types
+- Verify user role access is correct (admin vs. editor vs. anonymous)
+- Look for visible PHP warnings, notices, or deprecation messages in the page output
+- Check the Drupal status report (/admin/reports/status) for any new warnings or errors
+
+**Drupal Bug Fix:**
+- Reproduce the original bug scenario — confirm it no longer occurs
+- Test the affected page, view, or component directly
+- Check adjacent functionality (e.g. if a field was fixed, test the full form it belongs to)
+- Verify fix holds for different user roles if relevant
+
+**Drupal New Feature:**
+- Walk through the feature end-to-end as a content editor and as an anonymous user
+- Test edge cases mentioned in the task (empty states, required fields, access denial)
+- Verify the feature works correctly across relevant content types and user roles
+
+---
+
+#### WordPress-Specific Steps
+
+**WordPress Core / Plugin / Theme Update:**
+- Verify the site loads and the WordPress admin (/wp-admin) is accessible
+- Check that updated plugins are active and show the correct version under Plugins
+- Test any functionality the updated plugins affect (e.g. forms, eCommerce, SEO, page builder blocks)
+- Check the front-end for visual regressions — especially if a theme or page builder was updated
+- Verify the block editor (Gutenberg) or classic editor loads correctly and content is editable
+- Look for PHP errors or warnings in the page output or admin notices
+- Check WooCommerce checkout flow if applicable (cart to checkout to order confirmation)
+
+**WordPress Bug Fix:**
+- Reproduce the original bug — confirm it no longer occurs
+- Test the affected page, post type, or plugin feature directly
+- Check adjacent functionality that could have been impacted by the fix
+- Verify fix holds across user roles (admin, editor, subscriber, logged-out)
+
+**WordPress New Feature:**
+- Walk through the feature end-to-end as an admin and as a front-end user
+- Test edge cases mentioned in the task
+- If a custom post type, ACF field group, or shortcode is involved, test create/edit/publish/display
+- Verify the feature displays correctly in both the editor and on the published front-end
+
+---
+
+#### General Steps (applies to all platforms)
+
+**Bug Fix:**
+- Reproduce the original bug scenario — confirm it no longer occurs
+- Test the affected page/feature directly
+- Check adjacent functionality that could have been impacted
+
+**New Feature:**
+- Walk through the feature end-to-end as a user
+- Test edge cases mentioned in the task
+- Verify the feature behaves correctly for different user roles if relevant
+
+**General Web Dev:**
+- Test the specific pages or components mentioned
+- Verify visual output matches intent described in the task
+
+---
+
+Present the full validation plan to the user **before** executing — list all steps (base + dynamic) and confirm they want to proceed, or let them add/remove steps.
+
+---
+
+## Step 3 — Execute the Validation via CoWork
+
+Use CoWork browser automation to work through each validation step:
+
+- Navigate to the multi-dev URL
+- For each step:
+  - Perform the action
+  - Take a **screenshot** as evidence
+  - Record a **pass**, **fail**, or **warning** result
+  - Note any observations (what you saw, any errors, anything unexpected)
+- If a step fails or produces a warning, take an additional screenshot and note the exact error or issue observed
+- Check the browser console for JS errors on key pages where relevant
+
+Keep a running log as you go — don't wait until the end to compile results.
+
+---
+
+## Step 4 — Produce the Validation Report
+
+Once all steps are complete, output the full report in chat using the format below.
+
+---
+
+### Report Format
+
+```
+## QA Validation Report
+**Task:** [Task name + Teamwork link]
+**Multi-Dev URL:** [URL tested]
+**Platform:** [WordPress / Drupal]
+**Date:** [Today's date]
+**Overall Result:** PASS / PASS WITH WARNINGS / FAIL
+
+---
+
+### Validation Steps
+
+| # | Step | Result | Notes |
+|---|------|--------|-------|
+| 1 | Site loads without errors | Pass | No errors observed |
+| 2 | Homepage renders correctly | Pass | |
+| 3 | [Dynamic step] | Fail | [Description of issue] |
+...
+
+---
+
+### Issues Found
+
+> Only include this section if there are failures or warnings.
+
+**[Issue Title]** — [FAIL / WARNING]
+- **Where:** [Page or component]
+- **What happened:** [Description]
+- **Screenshot:** [Attached or described]
+
+---
+
+### Internal Notes
+
+[Anything the developer or team should know — technical observations, potential causes, suggested follow-up]
+
+---
+
+### Client-Facing Summary
+
+[2-4 sentence plain-English summary suitable for sending to a client. Tone should match the
+examples in the user's preferences: professional, friendly, concise. If all passed: confirm
+the feature/fix is working as expected and invite their review. If issues were found: describe
+what was found plainly and what the next step is.]
+```
+
+---
+
+## Notes & Edge Cases
+
+- If CoWork can't access the multi-dev URL (auth wall, VPN required, etc.), stop and notify the user.
+- If a step can't be completed due to missing credentials (e.g. admin login required), skip it, mark as **Skipped**, and note what access would be needed.
+- If the task has no clear multi-dev URL and none can be inferred, ask before proceeding.
+- **Drupal:** Pay special attention to PHP notices/warnings in the page output — they often indicate module compatibility issues even when the page appears functional.
+- **WordPress:** Pay attention to admin notices and plugin conflict warnings at the top of the /wp-admin dashboard — these often surface issues that don't appear on the front-end.
+- Screenshots should be captured at key moments: initial page load, after interactions, and on any failures.

--- a/tests/test-plugin.bats
+++ b/tests/test-plugin.bats
@@ -90,9 +90,9 @@ setup() {
   [ -d "skills" ]
 }
 
-@test "skill count matches expected (41)" {
+@test "skill count matches expected (45)" {
   count=$(find skills -mindepth 1 -maxdepth 1 -type d | wc -l)
-  [ "$count" -eq 41 ]
+  [ "$count" -eq 45 ]
 }
 
 @test "all skill directories have SKILL.md file" {
@@ -516,6 +516,37 @@ setup() {
 
 @test "structured-data-analyzer skill exists" {
   [ -f "skills/structured-data-analyzer/SKILL.md" ]
+}
+
+# ==============================================================================
+# PLANNING + PM SKILLS TESTS
+# ==============================================================================
+
+@test "planning skills exist" {
+  [ -f "skills/frd-generator/SKILL.md" ]
+  [ -f "skills/story-point-estimator/SKILL.md" ]
+  [ -f "skills/csv-exporter/SKILL.md" ]
+}
+
+@test "planning skill templates exist" {
+  [ -f "skills/frd-generator/templates/frd-structure.md" ]
+  [ -f "skills/frd-generator/templates/risk-framework.md" ]
+  [ -f "skills/story-point-estimator/templates/fibonacci-scale.md" ]
+  [ -f "skills/story-point-estimator/templates/hour-conversion-table.md" ]
+  [ -f "skills/csv-exporter/templates/teamwork-format.md" ]
+  [ -f "skills/csv-exporter/templates/hierarchy-examples.md" ]
+}
+
+@test "PM skills exist" {
+  [ -f "skills/client-request-triage/SKILL.md" ]
+  [ -f "skills/pm-meeting-prep/SKILL.md" ]
+  [ -f "skills/project-heartbeat/SKILL.md" ]
+  [ -f "skills/qa-review/SKILL.md" ]
+}
+
+@test "planning and PM doc pages exist" {
+  [ -f "docs/commands/planning.md" ]
+  [ -f "docs/commands/pm-workflows.md" ]
 }
 
 # ==============================================================================

--- a/zensical.toml
+++ b/zensical.toml
@@ -3,7 +3,7 @@
 
 [project]
 site_name = "CMS Cultivator"
-site_description = "Claude Code plugin for Drupal and WordPress development with 41 agent skills for Claude Code, Claude Desktop, and OpenAI Codex"
+site_description = "Claude Code plugin for Drupal and WordPress development with 45 agent skills for Claude Code, Claude Desktop, and OpenAI Codex"
 site_url = "https://kanopi.github.io/cms-cultivator/"
 site_author = "Kanopi Studios"
 copyright = "Copyright &copy; 2025 Kanopi Studios"
@@ -33,7 +33,8 @@ nav = [
     "commands/code-quality.md",
     "commands/devops.md",
     "commands/project-management.md",
-    "commands/planning.md"
+    "commands/planning.md",
+    "commands/pm-workflows.md"
   ]},
   {"Agents & Skills" = "agents-and-skills.md"},
   {"WordPress Skills" = "wordpress-skills.md"},


### PR DESCRIPTION
## Summary

Adds four PM-focused workflow skills authored by Andrew Nichols that pull context from connected MCP servers to handle client communication, meeting prep, status updates, and QA review. Resolves [Teamwork 30053344](https://kanopi.teamwork.com/app/tasks/30053344).

> **Stacked on #34.** Base is \`feature/merge-cms-planner\` so skill counts add cleanly. After #34 merges, GitHub will retarget this PR to \`1.x\`.

### Skills added

- **\`client-request-triage\`** — Fetch a client Teamwork task, detect the platform, research 1–3 solution options, and draft a warm client-facing reply. Pauses for PM confirmation before drafting; flags bug reports.
  **MCPs:** Teamwork + web search
- **\`pm-meeting-prep\`** — Aggregate context from Teamwork (tasks + messages), Slack, Gmail, and Fathom into a structured client check-in briefing with talking points, blockers, and suggested next steps. Optionally generates a meeting agenda.
  **MCPs:** Teamwork + Slack + Gmail + Fathom
- **\`project-heartbeat\`** — Draft a client-facing status update message ready to post as a Teamwork reply. Finds the existing heartbeat thread, reads the most recent reply to set the reporting window, then pulls completed tasks, project messages, Fathom summaries, and Slack channel activity. Written in a warm, progress-forward voice with budget/timeline placeholders.
  **MCPs:** Teamwork + Slack + Fathom
- **\`qa-review\`** — Full QA validation of a multidev environment from a Teamwork task. Reads task and all comments, extracts the multidev URL, detects the platform, builds a dynamic validation plan, executes via CoWork browser automation, and produces a structured report with pass/fail per step, screenshots, internal notes, and a client-facing summary.
  **MCPs:** Teamwork + CoWork browser automation

### Counts

- **Skills:** 41 → 45 (assumes #34 merges first; if reordered, rebase)
- **Version:** 1.1.0 → 1.2.0
- **Agents:** unchanged

### Files changed

- 4 new \`skills/<name>/SKILL.md\` files
- \`.claude-plugin/plugin.json\`, \`.codex-plugin/plugin.json\` — version + description
- \`README.md\`, \`CLAUDE.md\`, \`skills/README.md\`, \`docs/index.md\`, \`docs/agents-and-skills.md\`, \`zensical.toml\` — counts and references
- \`docs/commands/pm-workflows.md\` — new page covering all four PM skills and their MCP setup
- \`tests/test-plugin.bats\` — count bump + new file-existence checks for planning + PM skills and doc pages
- \`CHANGELOG.md\` — v1.2.0 entry

## Notes

- **\`project-heartbeat\` voice.** Written in Andrew Nichols's personal voice (warm/collegial opener, signed "Cheers, Andrew"). Other PMs are encouraged to adjust signature and tone after the draft is generated. Docs flag this.
- **CoWork dependency.** Without CoWork, \`qa-review\` produces the validation plan but cannot execute it.
- **MCP requirement.** None of these skills can function without their MCP servers configured. The docs page explains setup.

## Test plan

- [x] \`./scripts/validate-frontmatter.sh\` — 0 errors, 0 warnings (8 SKILLs validated including the 4 new ones and the 3 from #34)
- [x] \`bats tests/test-plugin.bats\` — 88/88 pass (added 4 new tests for planning/PM skill file existence and doc page existence)
- [x] \`zensical build --clean\` — succeeds
- [ ] Reviewer: confirm Teamwork/Slack/Gmail/Fathom MCPs are connected and invoke each skill against a real project
- [ ] Reviewer (with CoWork): try \`qa-review\` against a multidev task to verify the validation report renders

- [x] Was AI used in this pull request?