### PR TITLE
feat(packaging): script + CI to build .skill files for Claude Desktop

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -20,16 +20,15 @@ permissions:
   contents: write
 
 jobs:
-  package-skills:
+  package:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          # Full history so `git archive HEAD` resolves cleanly on the checked-out tag.
+          fetch-depth: 0
           ref: ${{ github.event.release.tag_name || github.event.inputs.tag }}
-
-      - name: Package skills
-        run: bash scripts/package-skills.sh
 
       - name: Determine target tag
         id: tag
@@ -40,21 +39,32 @@ jobs:
             echo "value=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Attach .skill files and bundle to the release
+      - name: Package the full plugin (cms-cultivator.zip)
+        run: bash scripts/package-plugin.sh
+
+      - name: Package individual skills (.skill files + bundle)
+        run: bash scripts/package-skills.sh
+
+      - name: Attach artifacts to the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.tag.outputs.value }}"
           echo "Attaching artifacts to release: $TAG"
 
-          # Upload each individual .skill file (with --clobber so re-runs replace)
+          # Full plugin zip (for Claude Desktop's "Add plugin" UI)
+          gh release upload "$TAG" dist/cms-cultivator.zip \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+
+          # Individual .skill files (for Chat / CoWork skill upload)
           for f in dist/skills/*.skill; do
             gh release upload "$TAG" "$f" \
               --repo "$GITHUB_REPOSITORY" \
               --clobber
           done
 
-          # Upload the bundle
+          # All-skills bundle
           gh release upload "$TAG" dist/cms-cultivator-skills.zip \
             --repo "$GITHUB_REPOSITORY" \
             --clobber

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,60 @@
+name: Release Artifacts
+
+# Attach pre-built .skill files to every GitHub release so users can
+# download individual skills directly without cloning the repo.
+#
+# Triggers on release publish (automatic for new releases) and
+# workflow_dispatch (manual, to retroactively attach artifacts to an
+# existing release).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to attach .skill artifacts to (e.g. v1.2.1)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  package-skills:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+
+      - name: Package skills
+        run: bash scripts/package-skills.sh
+
+      - name: Determine target tag
+        id: tag
+        run: |
+          if [ -n "${{ github.event.release.tag_name }}" ]; then
+            echo "value=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Attach .skill files and bundle to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.value }}"
+          echo "Attaching artifacts to release: $TAG"
+
+          # Upload each individual .skill file (with --clobber so re-runs replace)
+          for f in dist/skills/*.skill; do
+            gh release upload "$TAG" "$f" \
+              --repo "$GITHUB_REPOSITORY" \
+              --clobber
+          done
+
+          # Upload the bundle
+          gh release upload "$TAG" dist/cms-cultivator-skills.zip \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ composer.lock
 
 # Build artifacts
 *.log
+/dist/
 
 # Claude
 .claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `scripts/package-skills.sh` — packages each skill in `skills/` as a `.skill` zip in `dist/skills/`, plus a bundled `dist/cms-cultivator-skills.zip` containing all of them. Each `.skill` is ready to drag-and-drop into Claude Desktop's Skills UI (Chat and CoWork surfaces). Supports filtering by skill name, `--list`, and `--no-bundle`.
+- `.github/workflows/release-artifacts.yml` — attaches every `.skill` file and the bundle zip to every GitHub release automatically. Triggers on `release: published` for new tags, and supports `workflow_dispatch` to retroactively attach artifacts to an existing release.
+- `docs/installation.md` "Claude Desktop — Chat and CoWork" section explaining the upload process, where to download pre-built `.skill` artifacts from a release, and how to build them from source.
+- BATS tests for the packaging script (existence, executable, `--list` count matches actual skill count) and the release workflow file.
+
+### Notes
+The upload itself remains a manual step in Claude Desktop's UI — Anthropic doesn't expose a Desktop skill API or marketplace integration for Chat/CoWork surfaces today. This release automates everything we control on the plugin side (packaging + distribution).
+
 ## [1.2.1] - 2026-05-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `scripts/package-plugin.sh` — packages the full plugin as `dist/cms-cultivator.zip`, ready to upload via Claude Desktop's "Add plugin" UI (covers the Claude Code surface inside Desktop). Uses `git archive` with a pathspec so only runtime-relevant paths are included (`.claude-plugin/`, `.codex-plugin/`, `.codex/`, `agents/`, `skills/`, plus AGENTS.md / CHANGELOG.md / CLAUDE.md / LICENSE.md / README.md). Excludes internal tooling (`.beads/`, `scripts/`, `tests/`), docs site source, and CI config. Supports archiving a specific tag/ref/SHA.
 - `scripts/package-skills.sh` — packages each skill in `skills/` as a `.skill` zip in `dist/skills/`, plus a bundled `dist/cms-cultivator-skills.zip` containing all of them. Each `.skill` is ready to drag-and-drop into Claude Desktop's Skills UI (Chat and CoWork surfaces). Supports filtering by skill name, `--list`, and `--no-bundle`.
-- `.github/workflows/release-artifacts.yml` — attaches every `.skill` file and the bundle zip to every GitHub release automatically. Triggers on `release: published` for new tags, and supports `workflow_dispatch` to retroactively attach artifacts to an existing release.
-- `docs/installation.md` "Claude Desktop — Chat and CoWork" section explaining the upload process, where to download pre-built `.skill` artifacts from a release, and how to build them from source.
-- BATS tests for the packaging script (existence, executable, `--list` count matches actual skill count) and the release workflow file.
+- `.github/workflows/release-artifacts.yml` — attaches the full plugin zip, every `.skill` file, and the all-skills bundle to every GitHub release automatically. Triggers on `release: published` for new tags, and supports `workflow_dispatch` to retroactively attach artifacts to an existing release.
+- `docs/installation.md` "Claude Desktop" section explaining the three Desktop surfaces (Claude Code, Chat, CoWork), which artifact to use for each, and how to build them from source.
+- BATS tests for both packaging scripts (existence, executable, `--list` count matches actual skill count) and the release workflow file.
 
 ### Notes
-The upload itself remains a manual step in Claude Desktop's UI — Anthropic doesn't expose a Desktop skill API or marketplace integration for Chat/CoWork surfaces today. This release automates everything we control on the plugin side (packaging + distribution).
+The uploads themselves remain manual steps in Claude Desktop's UI — Anthropic doesn't expose a Desktop plugin/skill API or marketplace integration for Chat/CoWork surfaces today. This release automates everything we control on the plugin side (packaging + distribution).
 
 ## [1.2.1] - 2026-05-14
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -178,32 +178,43 @@ Team members can override project settings in `.claude/settings.local.json` (not
 
 ---
 
-## Claude Desktop — Chat and CoWork
+## Claude Desktop
 
-Installing CMS Cultivator as a plugin in Claude Desktop only covers the embedded **Claude Code** surface. For **Chat** and **CoWork**, you need to upload skills individually as `.skill` files through Claude Desktop's Skills UI — there is no batch upload, marketplace integration, or public API for those surfaces today.
+Claude Desktop has **three** surfaces, each with its own upload path:
 
-To minimise the manual work, every CMS Cultivator GitHub release attaches pre-built `.skill` files (one per skill) and a bundled zip containing all of them.
+| Surface | Upload | Pre-built artifact |
+|---------|--------|---------------------|
+| **Claude Code** (embedded in Desktop) | Add plugin (one zip) | `cms-cultivator.zip` |
+| **Chat** | Upload each skill individually | `<skill-name>.skill` files (one per skill) |
+| **CoWork** | Upload each skill individually | `<skill-name>.skill` files (one per skill) |
+
+The marketplace install (Method 1 above) only covers Claude Code in the standalone CLI. For Claude Code **inside Desktop**, plus Chat and CoWork, you upload zips through Claude Desktop's UI. Every CMS Cultivator GitHub release attaches pre-built artifacts for all three surfaces so you don't have to build them yourself.
 
 ### Recommended: Download from a release
 
 1. Go to [the latest release](https://github.com/kanopi/cms-cultivator/releases/latest)
-2. Under **Assets**, download either:
-   - **`cms-cultivator-skills.zip`** — bundle of every skill (unzip locally to get the individual `.skill` files), or
-   - Individual **`<skill-name>.skill`** files for just the skills you want
-3. In Claude Desktop: **Settings → Skills → Upload Skill**
-4. Drag-and-drop each `.skill` file into the UI
+2. Under **Assets**, download what you need:
+   - **`cms-cultivator.zip`** — full plugin zip for Claude Code inside Desktop. Upload via **Settings → Plugins → Add plugin**.
+   - **`cms-cultivator-skills.zip`** — bundle of every skill for Chat/CoWork. Unzip locally to get the individual `.skill` files, then upload each via **Settings → Skills → Upload Skill**.
+   - Individual **`<skill-name>.skill`** files — if you only want specific skills for Chat or CoWork.
 
 ### Alternative: Build from source
 
-If you've cloned the repo, package the skills locally:
+If you've cloned the repo, package locally:
 
 ```bash
-./scripts/package-skills.sh
+./scripts/package-plugin.sh   # → dist/cms-cultivator.zip
+./scripts/package-skills.sh   # → dist/skills/<name>.skill + dist/cms-cultivator-skills.zip
 ```
 
-This produces `dist/skills/<skill-name>.skill` for every skill, plus a bundled `dist/cms-cultivator-skills.zip`. Each `.skill` file is a zip containing `<skill-name>/SKILL.md` and any associated templates.
+**`package-plugin.sh` options:**
 
-**Useful options:**
+```bash
+./scripts/package-plugin.sh         # archive HEAD
+./scripts/package-plugin.sh v1.2.1  # archive a specific tag/ref/SHA
+```
+
+**`package-skills.sh` options:**
 
 ```bash
 ./scripts/package-skills.sh                  # all skills + bundle
@@ -214,7 +225,7 @@ This produces `dist/skills/<skill-name>.skill` for every skill, plus a bundled `
 
 ### Why the manual step exists
 
-The upload itself isn't automatable — Anthropic doesn't expose a Desktop API or a marketplace for Chat/CoWork skills today. The script and release artifacts only handle the packaging side. Once Anthropic ships either a Desktop skill API or marketplace integration for those surfaces, this section will get shorter.
+The uploads themselves aren't automatable — Anthropic doesn't expose a Desktop plugin/skill API or a marketplace for Chat/CoWork skills today. The scripts and release artifacts only handle the packaging side. Once Anthropic ships either a Desktop API or marketplace integration for those surfaces, this section will get shorter.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -178,6 +178,46 @@ Team members can override project settings in `.claude/settings.local.json` (not
 
 ---
 
+## Claude Desktop — Chat and CoWork
+
+Installing CMS Cultivator as a plugin in Claude Desktop only covers the embedded **Claude Code** surface. For **Chat** and **CoWork**, you need to upload skills individually as `.skill` files through Claude Desktop's Skills UI — there is no batch upload, marketplace integration, or public API for those surfaces today.
+
+To minimise the manual work, every CMS Cultivator GitHub release attaches pre-built `.skill` files (one per skill) and a bundled zip containing all of them.
+
+### Recommended: Download from a release
+
+1. Go to [the latest release](https://github.com/kanopi/cms-cultivator/releases/latest)
+2. Under **Assets**, download either:
+   - **`cms-cultivator-skills.zip`** — bundle of every skill (unzip locally to get the individual `.skill` files), or
+   - Individual **`<skill-name>.skill`** files for just the skills you want
+3. In Claude Desktop: **Settings → Skills → Upload Skill**
+4. Drag-and-drop each `.skill` file into the UI
+
+### Alternative: Build from source
+
+If you've cloned the repo, package the skills locally:
+
+```bash
+./scripts/package-skills.sh
+```
+
+This produces `dist/skills/<skill-name>.skill` for every skill, plus a bundled `dist/cms-cultivator-skills.zip`. Each `.skill` file is a zip containing `<skill-name>/SKILL.md` and any associated templates.
+
+**Useful options:**
+
+```bash
+./scripts/package-skills.sh                  # all skills + bundle
+./scripts/package-skills.sh frd-generator    # one skill only
+./scripts/package-skills.sh --list           # print the skill names
+./scripts/package-skills.sh --no-bundle      # skip the all-in-one zip
+```
+
+### Why the manual step exists
+
+The upload itself isn't automatable — Anthropic doesn't expose a Desktop API or a marketplace for Chat/CoWork skills today. The script and release artifacts only handle the packaging side. Once Anthropic ships either a Desktop skill API or marketplace integration for those surfaces, this section will get shorter.
+
+---
+
 ## OpenAI Codex Installation
 
 CMS Cultivator includes a `.codex-plugin/plugin.json` manifest and Codex-compatible TOML agent files. Install it via the Codex plugin system.

--- a/scripts/package-plugin.sh
+++ b/scripts/package-plugin.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Package the entire plugin as dist/cms-cultivator.zip, ready to upload
+# to Claude Desktop's "Add plugin" UI (covers the Claude Code surface
+# inside Desktop). The zip contains a top-level cms-cultivator/ directory
+# with the plugin manifest, agents, skills, Codex artifacts, and
+# supporting docs needed at runtime.
+#
+# Uses `git archive` so only tracked files are included — no build
+# artifacts, no .git/, no node_modules, no dist/, no site/.
+#
+# Usage:
+#   ./scripts/package-plugin.sh             # archive HEAD
+#   ./scripts/package-plugin.sh <ref>       # archive a specific ref/tag/SHA
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+REF="${1:-HEAD}"
+OUTPUT="dist/cms-cultivator.zip"
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "Error: git is required." >&2
+  exit 1
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Error: not inside a git repository." >&2
+  exit 1
+fi
+
+if ! git rev-parse --verify "$REF" >/dev/null 2>&1; then
+  echo "Error: '$REF' is not a valid git ref." >&2
+  exit 1
+fi
+
+mkdir -p dist
+rm -f "$OUTPUT"
+
+# Include only the paths the plugin needs at runtime. Excludes internal
+# tooling (.beads, scripts, tests), CI config (.github, .gitattributes),
+# docs site source (docs, zensical.toml), and local state (.claude).
+git archive \
+  --format=zip \
+  --prefix=cms-cultivator/ \
+  -o "$OUTPUT" \
+  "$REF" \
+  -- \
+  .claude-plugin \
+  .codex-plugin \
+  .codex \
+  agents \
+  skills \
+  AGENTS.md \
+  CHANGELOG.md \
+  CLAUDE.md \
+  LICENSE.md \
+  README.md
+
+size=$(ls -l "$OUTPUT" | awk '{print $5}')
+files=$(unzip -l "$OUTPUT" | tail -1 | awk '{print $2}')
+
+echo "✓ $OUTPUT"
+echo "  ref:   $REF ($(git rev-parse --short "$REF"))"
+echo "  size:  $size bytes"
+echo "  files: $files"
+echo ""
+echo "Upload via Claude Desktop's plugin UI to enable the plugin in the"
+echo "Claude Code surface inside Desktop."

--- a/scripts/package-skills.sh
+++ b/scripts/package-skills.sh
@@ -58,9 +58,11 @@ if [ ! -d "skills" ]; then
   exit 1
 fi
 
-# Clean dist/ for full builds; preserve for single-skill builds
+# Clean our own output for full builds; preserve for single-skill builds.
+# Don't wipe sibling outputs (e.g. cms-cultivator.zip from package-plugin.sh).
 if [ -z "$TARGET" ]; then
-  rm -rf dist
+  rm -rf "$DIST_DIR"
+  rm -f "$BUNDLE_PATH"
 fi
 mkdir -p "$DIST_DIR"
 

--- a/scripts/package-skills.sh
+++ b/scripts/package-skills.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Package each skill in skills/ as a .skill zip in dist/skills/, ready to
+# upload to Claude Desktop's Chat or CoWork surfaces via the Skills UI.
+#
+# A .skill file is a zip containing <skill-name>/SKILL.md (and optionally
+# <skill-name>/templates/...). This script produces one .skill per
+# skills/<name>/ directory, plus a bundled cms-cultivator-skills.zip
+# containing all of them.
+#
+# Usage:
+#   ./scripts/package-skills.sh             # build all skills + bundle
+#   ./scripts/package-skills.sh <name>      # build a single skill
+#   ./scripts/package-skills.sh --list      # list skill names that would be built
+#   ./scripts/package-skills.sh --no-bundle # build .skill files but skip the bundle
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+DIST_DIR="dist/skills"
+BUNDLE_PATH="dist/cms-cultivator-skills.zip"
+
+BUILD_BUNDLE=1
+TARGET=""
+
+# Parse arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --list)
+      for skill_dir in skills/*/; do
+        skill_name=$(basename "$skill_dir")
+        [ -f "$skill_dir/SKILL.md" ] && echo "$skill_name"
+      done
+      exit 0
+      ;;
+    --no-bundle)
+      BUILD_BUNDLE=0
+      shift
+      ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    --*)
+      echo "Unknown flag: $1" >&2
+      exit 1
+      ;;
+    *)
+      TARGET="$1"
+      shift
+      ;;
+  esac
+done
+
+# Sanity check
+if [ ! -d "skills" ]; then
+  echo "Error: skills/ directory not found. Run from the repo root." >&2
+  exit 1
+fi
+
+# Clean dist/ for full builds; preserve for single-skill builds
+if [ -z "$TARGET" ]; then
+  rm -rf dist
+fi
+mkdir -p "$DIST_DIR"
+
+count=0
+for skill_dir in skills/*/; do
+  skill_name=$(basename "$skill_dir")
+
+  # Skip if filtering and no match
+  if [ -n "$TARGET" ] && [ "$TARGET" != "$skill_name" ]; then
+    continue
+  fi
+
+  # Skip directories without SKILL.md (e.g. README.md siblings)
+  if [ ! -f "$skill_dir/SKILL.md" ]; then
+    continue
+  fi
+
+  output="$(pwd)/$DIST_DIR/${skill_name}.skill"
+  rm -f "$output"
+
+  # Build .skill — zip contains <skill-name>/SKILL.md (+ templates/, etc.)
+  # Exclude macOS .DS_Store and the Codex-specific openai.yaml policy files
+  # (irrelevant to Claude Desktop).
+  ( cd skills && zip -qr "$output" "$skill_name" \
+      -x "*.DS_Store" \
+      -x "$skill_name/agents/openai.yaml" )
+
+  count=$((count + 1))
+  printf "  %s → %s\n" "$skill_name" "$DIST_DIR/${skill_name}.skill"
+done
+
+if [ "$count" -eq 0 ]; then
+  if [ -n "$TARGET" ]; then
+    echo "Error: no skill named '$TARGET' found under skills/" >&2
+    exit 1
+  fi
+  echo "Error: no skills with SKILL.md found under skills/" >&2
+  exit 1
+fi
+
+# Build the bundle (single skill builds skip it)
+if [ "$BUILD_BUNDLE" -eq 1 ] && [ -z "$TARGET" ]; then
+  rm -f "$BUNDLE_PATH"
+  ( cd "$DIST_DIR" && zip -qr "../$(basename "$BUNDLE_PATH")" . )
+  echo ""
+  echo "Bundle → $BUNDLE_PATH ($(ls -1 "$DIST_DIR"/*.skill | wc -l | tr -d ' ') skills)"
+fi
+
+echo ""
+echo "Built $count skill(s) → $DIST_DIR/"
+echo ""
+echo "Next steps:"
+echo "  • Upload each .skill to Claude Desktop via Settings → Skills"
+echo "  • Or download .skill files from a tagged GitHub release:"
+echo "    https://github.com/kanopi/cms-cultivator/releases/latest"

--- a/tests/test-plugin.bats
+++ b/tests/test-plugin.bats
@@ -613,6 +613,10 @@ setup() {
   [ -x "scripts/package-skills.sh" ]
 }
 
+@test "scripts/package-plugin.sh exists and is executable" {
+  [ -x "scripts/package-plugin.sh" ]
+}
+
 @test "scripts/package-skills.sh --list outputs every skill directory" {
   expected=$(find skills -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
   actual=$(bash scripts/package-skills.sh --list | wc -l | tr -d ' ')

--- a/tests/test-plugin.bats
+++ b/tests/test-plugin.bats
@@ -606,6 +606,27 @@ setup() {
 }
 
 # ==============================================================================
+# PACKAGING SCRIPT
+# ==============================================================================
+
+@test "scripts/package-skills.sh exists and is executable" {
+  [ -x "scripts/package-skills.sh" ]
+}
+
+@test "scripts/package-skills.sh --list outputs every skill directory" {
+  expected=$(find skills -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+  actual=$(bash scripts/package-skills.sh --list | wc -l | tr -d ' ')
+  if [ "$actual" != "$expected" ]; then
+    echo "Expected $expected skills, --list returned $actual"
+    return 1
+  fi
+}
+
+@test "release-artifacts workflow exists" {
+  [ -f ".github/workflows/release-artifacts.yml" ]
+}
+
+# ==============================================================================
 # DOCS-VS-SKILLS CONSISTENCY
 # ==============================================================================
 


### PR DESCRIPTION
## Summary

Adds tooling to automate the packaging side of getting CMS Cultivator skills into Claude Desktop's Chat and CoWork surfaces. The upload itself stays manual — Anthropic doesn't expose a Desktop skill API or marketplace integration for those surfaces today — but everything we control on the plugin side is automated.

## What's added

### \`scripts/package-skills.sh\`

Produces:
- \`dist/skills/<skill-name>.skill\` for every skill in \`skills/\`
- \`dist/cms-cultivator-skills.zip\` — bundle of all 46 skills

Each \`.skill\` file is a zip containing \`<skill-name>/SKILL.md\` and any templates. Excludes \`.DS_Store\` and Codex-specific \`agents/openai.yaml\` policy files (irrelevant to Claude Desktop).

**Usage:**

\`\`\`bash
./scripts/package-skills.sh                  # all skills + bundle
./scripts/package-skills.sh frd-generator    # one skill only
./scripts/package-skills.sh --list           # print the skill names
./scripts/package-skills.sh --no-bundle      # skip the bundle zip
\`\`\`

Verified locally: produces 46 \`.skill\` files + a 256KB bundle.

### \`.github/workflows/release-artifacts.yml\`

Attaches every \`.skill\` file and the bundle to every GitHub release:

- Triggers automatically on \`release: published\` (so future tagged releases get artifacts attached)
- Supports \`workflow_dispatch\` with a \`tag\` input (so we can retroactively attach artifacts to existing releases like v1.2.0 and v1.2.1)
- Uses \`--clobber\` so re-runs replace existing assets cleanly

### Docs

New \"Claude Desktop — Chat and CoWork\" section in \`docs/installation.md\`:

- Explains the limitation (no batch upload / marketplace today)
- Recommends downloading the bundle from a release
- Documents the build-from-source path for contributors
- Lists script options

### Tests

Three new BATS tests:

- \`scripts/package-skills.sh\` exists and is executable
- \`--list\` count matches actual skill directory count
- \`.github/workflows/release-artifacts.yml\` exists

98/98 BATS tests pass; frontmatter validation clean; Zensical builds clean.

## What's not in this PR

The upload to Claude Desktop is still manual — Anthropic doesn't expose an API or marketplace for Chat/CoWork skills. We're not building a browser-automation script for that today; it'd be fragile against any UI change. The docs section explains this limitation up front.

## Follow-up after merge

Once this merges, I'll trigger the workflow manually against \`v1.2.1\` to retroactively attach the \`.skill\` artifacts to the most recent release. Future releases will get artifacts attached automatically.

## Test plan

- [x] \`./scripts/package-skills.sh\` produces 46 .skill files + bundle locally
- [x] \`./scripts/package-skills.sh --list\` outputs 46 names
- [x] \`./scripts/package-skills.sh frd-generator\` builds just that one
- [x] BATS 98/98 pass
- [x] YAML validation clean for the release workflow
- [x] Zensical build clean
- [ ] Reviewer: pull the branch, run the script, drag a \`.skill\` into Claude Desktop, confirm it loads

- [x] Was AI used in this pull request?