### PR TITLE
feat(worktree-manager): add git worktree management skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `skills/worktree-manager/SKILL.md` — new skill to create, list, and tear down git worktrees following Kanopi's branch naming conventions, so developers and AI sessions can work multiple tickets in parallel from a single clone. Handles automatic DDEV isolation (folder-derived project name, no pinned ports) for Drupal and WordPress, port-separated `npm run dev` for Next.js, and gates destructive removals behind explicit confirmation. Documented in `docs/commands/pr-workflow.md` and `docs/commands/overview.md`.
+
 ## [1.3.0] - 2026-05-22
 
 ### Added

--- a/docs/agents-and-skills.md
+++ b/docs/agents-and-skills.md
@@ -29,7 +29,7 @@ Agents are specialized AI assistants that handle complex, multi-step workflows. 
 - **testing-specialist** - Test generation and coverage (inline security and accessibility test scenarios)
 - **design-specialist** - Design-to-code generation (code generation only; skill spawns responsive-styling and browser-validator agents)
 
-PR workflows (`pr-create`, `pr-review`, `pr-release`, `commit-message-generator`) run **directly from the main session** without an orchestrator agent — each skill contains its complete workflow.
+PR and development-workflow skills (`pr-create`, `pr-review`, `pr-release`, `commit-message-generator`, `worktree-manager`) run **directly from the main session** without an orchestrator agent — each skill contains its complete workflow.
 
 ### How Agents Work
 

--- a/docs/commands/overview.md
+++ b/docs/commands/overview.md
@@ -24,6 +24,7 @@ Streamline pull request creation, review, and deployment. PR skills run directly
 | `pr-create` | Create a pull request with a generated description (presents for approval before running `gh pr create`) |
 | `pr-review` | Review a PR (`/pr-review 123`) or self-review your branch (`/pr-review self`) with focus areas: code, security, breaking, testing, size, performance |
 | `pr-release` | Generate changelog (Keep a Changelog format), deployment checklist, and PR description update |
+| `worktree-manager` | Create, list, and tear down git worktrees with Kanopi branch naming and automatic DDEV isolation so multiple tickets (and AI sessions) run in parallel from one clone |
 
 ---
 

--- a/docs/commands/pr-workflow.md
+++ b/docs/commands/pr-workflow.md
@@ -1,10 +1,38 @@
 # PR Workflow Skills
 
-Streamline pull request creation, review, and deployment with 4 specialized skills.
+Streamline the development lifecycle — from isolating a ticket in its own worktree through pull request creation, review, and deployment.
 
 ---
 
 ## Skills
+
+### `worktree-manager [create|list|remove]`
+
+Create, list, and tear down git worktrees so multiple tickets — and multiple AI sessions — run side by side from a single clone.
+
+**Usage:**
+```bash
+/worktree-manager create 1234 hero-block       # new worktree + feature/tw1234-hero-block
+/worktree-manager create 1235 menu-fix --type bug
+/worktree-manager list                          # show active worktrees + DDEV status
+/worktree-manager remove 1234                   # tear down (asks for confirmation first)
+```
+
+**What it does:**
+1. Creates a sibling worktree directory mirroring the branch (`../<repo>-tw1234`)
+2. Branches off the up-to-date remote base using Kanopi naming (`<type>/tw<id>-<short-desc>`)
+3. Runs platform setup — DDEV (`start`, `composer install`, theme build, `db-refresh`) for Drupal/WordPress, or port-separated `npm run dev` for Next.js
+4. Reports the directory, branch, and local URL, plus how to attach a CLI or Desktop session
+5. On removal, gates the destructive teardown (worktree, branch, DDEV project + database) behind explicit confirmation
+
+**Why worktrees:**
+- Run two Claude Code sessions (or a CLI session and a Claude Desktop "code" session) on different tickets at once — no `git checkout` thrash
+- Maps one-to-one onto Kanopi's "one branch per ticket" rule
+- DDEV isolation is automatic when the project name is folder-derived (no committed `name:`, no pinned ports)
+
+**Requires:** Git with worktree support; DDEV for Drupal/WordPress setup steps
+
+---
 
 ### `pr-create [ticket-number]`
 
@@ -137,6 +165,9 @@ Generate changelog, deployment checklist, and update PR for release.
 ### Complete PR Workflow
 
 ```bash
+# 0. Starting a ticket - isolate it in its own worktree (optional)
+/worktree-manager create 123 feature-name   # fresh worktree + branch, DDEV isolated
+
 # 1. During development - commit frequently
 git add feature.php
 /commit-message-generator            # Generate conventional commit
@@ -231,6 +262,11 @@ See [Kanopi Tools](../kanopi-tools/overview.md) for more information.
 ## Skill Comparison
 
 ### When to use each skill:
+
+**`/worktree-manager`**
+- Starting a ticket without disturbing your current working tree
+- Running two tickets — or two AI sessions — in parallel from one clone
+- Cleaning up a finished ticket's worktree, branch, and DDEV project
 
 **`/pr-create`**
 - You're ready to create a PR

--- a/skills/README.md
+++ b/skills/README.md
@@ -410,6 +410,11 @@ Detailed instructions for Claude on how to execute this skill...
 **Audience**: strategists, UX leads, PMs — not developers.
 **Tool dependencies**: CoWork browser automation, web search (optional)
 
+### 47. worktree-manager
+
+**Triggers**: "create a worktree", "new worktree for tw1234", "spin up a parallel branch", "work on two tickets at once", "/worktree-manager", "I need to work on another ticket without losing my current one"
+**Purpose**: Create, list, and tear down git worktrees following Kanopi's branch naming conventions so developers and AI sessions can work multiple tickets in parallel from a single clone. Handles DDEV isolation automatically (folder-derived project name, no pinned ports) for Drupal and WordPress, plain port-separated setup for Next.js, and gates destructive removals behind explicit confirmation.
+
 ## Adding New Skills
 
 To add a new Agent Skill:

--- a/skills/worktree-manager/SKILL.md
+++ b/skills/worktree-manager/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: worktree-manager
+description: Create, list, and tear down git worktrees following Kanopi's branch naming conventions so developers and agents can work multiple tickets in parallel without clobbering each other's working tree. Handles DDEV isolation automatically (folder-derived project name, no pinned ports) for Drupal and WordPress, and plain worktree setup for Next.js. Invoke when the user wants to start a ticket in a fresh worktree, run more than one Claude Code or Claude Desktop session at once, says "create a worktree", "new worktree for tw1234", "spin up a parallel branch", "work on two tickets at once", "/worktree-manager", or asks how to clean up a finished worktree. Use this skill even if the user only says "I need to work on another ticket without losing my current one."
+---
+
+# Worktree Manager
+
+Create and tear down git worktrees that follow Kanopi's branch conventions and stay isolated at the DDEV layer, so multiple tickets — and multiple AI sessions — can run side by side from a single clone.
+
+## Why this exists
+
+A worktree checks out a second branch into its own directory while sharing one `.git`. That is the primitive that lets two Claude Code sessions (or one CLI session and one Claude Desktop "code" session) work different tickets at the same time without `git checkout` thrash or stepping on each other's files. It maps one-to-one onto Kanopi's "one branch per ticket" rule.
+
+## Usage
+
+- `/worktree-manager create <ticket-id> <short-desc> [--type feature|bug|hotfix] [--base main]` — create a worktree + branch
+- `/worktree-manager list` — show active worktrees and their DDEV status
+- `/worktree-manager remove <ticket-id>` — tear down a worktree (destructive; requires confirmation)
+
+If the user gives a Teamwork URL or task ID, parse the numeric ID from it (e.g. `tw1234`).
+
+## Naming convention
+
+Branch (unchanged from Kanopi standards):
+
+```
+<type>/tw<ticketID>-<short-desc>
+# feature/tw1234-hero-block
+# bug/tw1235-menu-fix
+# hotfix/tw1236-login-error
+```
+
+For a sub-task or dependent feature, use the **parent** task ID, matching the complex-feature parent/child model.
+
+Worktree directory — a sibling of the main clone, named to mirror the branch:
+
+```
+<repo>/                       # main clone, stays on main
+<repo>-tw1234/                # worktree for feature/tw1234-hero-block
+<repo>-tw1235/                # worktree for bug/tw1235-menu-fix
+```
+
+Keep worktrees as siblings (not nested inside the main clone) so build tooling, IDE indexers, and DDEV file mounts don't recurse into them.
+
+## Environment Detection
+
+### Tier 1 — Portable (Claude Desktop, Codex, any environment)
+
+When `Bash`/git execution is unavailable, output the exact commands for the user to run, then explain how to point their environment at the new directory:
+
+- **Claude Code CLI:** `cd ../<repo>-tw1234` then launch a session there.
+- **Claude Desktop (code section):** open the worktree directory as the project folder. Run one Desktop project per worktree if working two in parallel.
+
+### Tier 2 — Enhanced (Claude Code with Bash/git)
+
+Run the steps directly, pausing at the confirmation gate for destructive actions.
+
+## Create workflow
+
+1. **Resolve inputs** — ticket ID, short description (kebab-case, ≤4 words), type (default `feature`), base branch (default `main`).
+2. **Sync base** so the worktree starts current:
+   ```bash
+   git fetch origin
+   ```
+3. **Create the worktree + branch** off the up-to-date remote base:
+   ```bash
+   git worktree add ../<repo>-tw<id> -b <type>/tw<id>-<short-desc> origin/<base>
+   ```
+   If the branch already exists (resuming work), omit `-b`:
+   ```bash
+   git worktree add ../<repo>-tw<id> <type>/tw<id>-<short-desc>
+   ```
+4. **Run platform setup** — see Platform Notes below.
+5. **Report** the directory path, branch name, and (for DDEV projects) the local URL from `ddev describe`, plus the Tier 1 instructions for attaching a CLI or Desktop session.
+
+## Platform Notes
+
+### Drupal & WordPress (DDEV)
+
+DDEV isolation is automatic when the project name is folder-derived — i.e. `name:` is omitted from `.ddev/config.yaml`, so DDEV uses the directory name. Each worktree then gets its own hostname, database, and auto-assigned host ports, and the shared router keeps them from colliding. This is DDEV's documented recommendation for worktrees.
+
+If a project still commits a `name:` (or pins host ports), the second worktree will collide when it runs `ddev start`. Don't try to fix that repo-wide as part of this skill — surface the collision clearly and let the developer resolve it in their own config when they hit it. The quick local fix is a gitignored `config.local.yaml` in the worktree with a unique `name:`; the cleaner long-term fix is dropping the committed `name:` line on that project, but that's the team's call, not this skill's.
+
+Setup inside the new worktree:
+
+```bash
+cd ../<repo>-tw<id>
+ddev start
+ddev composer install
+ddev theme-install            # WP/Drupal theme deps + build
+ddev db-refresh               # each worktree gets its own DB
+```
+
+> Cost note: a worktree starts with an empty database, so it needs its own `ddev db-refresh` (or an imported snapshot). `vendor/` and `node_modules/` are directory-local, so they install per worktree — isolation by design, at the cost of disk + setup time.
+
+On push, CircleCI spins up a per-branch Pantheon multidev, so each worktree's branch also gets its own remote preview without extra steps.
+
+### Next.js (headless/decoupled)
+
+No DDEV. Create the worktree, then install and run the dev server on a distinct port:
+
+```bash
+cd ../<repo>-tw<id>
+npm install
+npm run dev -- -p 3001        # use a different port per parallel worktree
+```
+
+If platform is ambiguous (no `.ddev/`, no `next.config.*`), ask which platform is in scope before running setup.
+
+## Remove workflow (destructive — confirm first)
+
+**Confirmation gate:** state exactly what will be deleted (worktree directory, local branch if merged, DDEV project + database) and wait for explicit approval before proceeding.
+
+1. **Verify the branch is merged** (or the user confirms abandoning it):
+   ```bash
+   git branch --merged main | grep <type>/tw<id>
+   ```
+2. **Tear down DDEV** for that project (snapshot kept by default for safety):
+   ```bash
+   ddev delete -Oy <project-name>   # omit -O to keep a recovery snapshot
+   ```
+3. **Remove the worktree and prune:**
+   ```bash
+   git worktree remove ../<repo>-tw<id>
+   git worktree prune
+   ```
+4. **Delete the local branch** once merged (mirrors Kanopi's branch-cleanup discipline):
+   ```bash
+   git branch -d <type>/tw<id>-<short-desc>
+   ```
+   Use `-D` only with explicit confirmation — it discards unmerged work.
+
+## Quality Gates
+
+Before reporting a create as complete:
+1. ✅ Worktree directory exists and is on the expected branch (`git -C ../<repo>-tw<id> branch --show-current`)
+2. ✅ Base was fetched before branching
+3. ✅ For DDEV projects: the site responds (`ddev describe`)
+
+Before a remove:
+1. ✅ User explicitly approved the deletion
+2. ✅ Branch is merged, or user confirmed abandoning unmerged work
+3. ✅ DDEV project torn down before the directory is removed
+
+## Notes
+
+- Never create a worktree inside the main clone's working tree.
+- Don't reuse a ticket ID across two live worktrees.
+- This skill changes local state only; it never force-pushes or deletes remote branches.

--- a/tests/test-plugin.bats
+++ b/tests/test-plugin.bats
@@ -90,9 +90,9 @@ setup() {
   [ -d "skills" ]
 }
 
-@test "skill count matches expected (46)" {
+@test "skill count matches expected (47)" {
   count=$(find skills -mindepth 1 -maxdepth 1 -type d | wc -l)
-  [ "$count" -eq 46 ]
+  [ "$count" -eq 47 ]
 }
 
 @test "all skill directories have SKILL.md file" {


### PR DESCRIPTION
## Description

Adds a new `worktree-manager` Agent Skill that creates, lists, and tears down git worktrees following Kanopi's branch naming conventions, so developers and AI sessions can work multiple tickets in parallel from a single clone. Handles automatic DDEV isolation for Drupal/WordPress (folder-derived project name, no pinned ports), port-separated `npm run dev` for Next.js, and gates destructive removals behind explicit confirmation.

## Acceptance Criteria

* `worktree-manager/SKILL.md` exists with valid frontmatter and uses the correct `/worktree-manager` command form.
* The skill is documented in `docs/commands/pr-workflow.md`, `docs/commands/overview.md`, `skills/README.md`, and `docs/agents-and-skills.md`.
* CHANGELOG `[Unreleased]` records the new skill.
* `validate-frontmatter.sh` passes and all BATS tests pass (skill count bumped 46 -> 47).

## Steps to Validate

1. `./scripts/validate-frontmatter.sh` -> 0 errors.
2. `bats tests/test-plugin.bats` -> all tests pass.
3. Confirm `docs/commands/pr-workflow.md` renders the new `worktree-manager` section and the overview category table lists it.

## Affected URL

N/A (plugin + documentation only)

## Deploy Notes

None — no runtime/CMS changes. Docs site redeploys from `1.x` on merge.

- [x] Was AI used in this pull request?