### PR TITLE
fix(security-scan): mark example API_KEY placeholder in documentation-specialist

### DIFF
--- a/agents/documentation-specialist/AGENT.md
+++ b/agents/documentation-specialist/AGENT.md
@@ -343,8 +343,10 @@ wp plugin activate my-plugin
 Create `.env` file:
 
 \`\`\`env
+# Example placeholders only — set real secrets via your environment / a secrets
+# manager and never commit them to version control.
 DATABASE_URL=mysql://user:pass@localhost/dbname
-API_KEY=your_api_key_here
+API_KEY=example_api_key_here  # placeholder — replace with your real key
 DEBUG_MODE=false
 \`\`\`
 


### PR DESCRIPTION
## Summary

Fixes the failing **Security Scan** CI job (e.g. on #46, but it fails on *any* PR branched from `main`). The scan greps `skills/ agents/ docs/` for `password=` / `api_key=` / `secret=` and excludes lines containing `example` / `placeholder` / `TODO`. A documentation example in `agents/documentation-specialist/AGENT.md` tripped it:

```env
API_KEY=your_api_key_here
```

This is **not a real secret** — it's a sample `.env` block showing how to document environment variables — but the line carried no allowlisted marker, so the scan exited 1.

## Fix

Reword the placeholder so the scanner recognizes it as an example, and add a comment reinforcing that real secrets are never committed:

```env
# Example placeholders only — set real secrets via your environment / a secrets
# manager and never commit them to version control.
DATABASE_URL=mysql://user:pass@localhost/dbname
API_KEY=example_api_key_here  # placeholder — replace with your real key
DEBUG_MODE=false
```

## Why a separate PR

This is pre-existing debt on `main`, independent of the skill work in #46. Keeping it isolated lets it merge fast and unblock every open PR's Security Scan (rebase #46 on `main` afterward to pick up the green check).

## Testing

- Reproduced the exact CI scan locally → now reports `✅ No hardcoded secrets detected`.
- `./scripts/validate-frontmatter.sh` → clean; `bats tests/test-plugin.bats` → 99/99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
