### PR TITLE
chore(skills): allow model invocation for audit, PR, and devops skills

### DIFF
--- a/2026-06-05-docs-audit-and-consistency-plan.md
+++ b/2026-06-05-docs-audit-and-consistency-plan.md
@@ -1,0 +1,129 @@
+# Docs Audit & Consistency Plan
+
+**Date:** 2026-06-05
+**Branch:** 1.x
+
+---
+
+## Summary
+
+The category pages (`docs/commands/`) are accurate and well-organized. The main problems are: two agents undocumented in `agents-and-skills.md`, hardcoded counts scattered across docs and tests, several broken/stale references, and an 816-line page that tries to document agents and skills simultaneously with redundant verbose examples.
+
+---
+
+## Principle: No Hardcoded Counts
+
+Counts go stale every time a skill or agent is added. Do not put counts in documentation prose or test assertions. If a BATS test needs to verify parity between two sets (e.g. agents vs. Codex TOMLs), compute both dynamically and compare them.
+
+---
+
+## Issues Found
+
+### 1. Missing agents in `agents-and-skills.md`
+
+Two agents exist in `/agents/` but are absent from every section of `agents-and-skills.md`:
+
+- `drupalorg-issue-specialist`
+- `drupalorg-mr-specialist`
+
+Needs to be added to:
+- Leaf Specialists list
+- "Agent-to-Skill Mapping (Spawned By)" table
+- "Agent-to-Skill Mapping (Uses Skills)" table
+
+Reference: `drupal-contribution.md` already documents them correctly — copy that pattern.
+
+---
+
+### 2. Hardcoded counts in docs
+
+| File | Line | Count | Fix |
+|---|---|---|---|
+| `docs/wordpress-skills.md` | 223 | "CMS Cultivator Skills (14)" | Remove the count, use a heading without a number |
+| `docs/wordpress-skills.md` | 233 | "WordPress Skills (13)" | Remove the count |
+| `docs/testing.md` | 100 | "Command count matches expected (25)" | Update example output or remove the count from the label |
+
+---
+
+### 3. Hardcoded counts in BATS tests (`tests/test-plugin.bats`)
+
+| Line | Test | Fix |
+|---|---|---|
+| 93–95 | `[ "$count" -eq 46 ]` skill count | Remove assertion or replace with `[ "$count" -gt 0 ]` |
+| 177–178, 190–191 | `[ "$count" -eq 14 ]` agent count | Same |
+| 867–869 | `[ "$toml_count" -eq 14 ]` Codex TOML count | Replace with dynamic parity check: compare TOML count to agent dir count |
+
+The Codex TOML parity test is worth keeping — it catches a missing translation file — but rewrite it as `[ "$toml_count" -eq "$agent_count" ]` so it never needs manual updating.
+
+---
+
+### 4. `commands/overview.md` — tip text has a self-referential typo (line 11)
+
+```
+The accessibility skill is `accessibility-audit`, not `accessibility-audit`.
+The commit message helper is `commit-message-generator`, not `commit-message-generator`.
+```
+
+Both sides of "not" are identical. Either fix to show the actual old pre-v1.0 names (from `reference/skill-naming-convention.md`), or remove the tip if old names are no longer relevant.
+
+---
+
+### 5. `wordpress-skills.md` — broken links
+
+- Line 365: `[CMS Cultivator Skills](agent-skills.md)` → should be `agents-and-skills.md`
+- Line 366: `[Drupal Skills](drupal-org-integration.md)` → should be `drupal-contribution.md`
+
+---
+
+### 6. `agents-and-skills.md` — duplicate section heading and skill numbering
+
+- Two separate sections both called "Agent-to-Skill Mapping" (lines 112 and 130) — confusing to navigate
+- Skill number "10." appears twice (structured-data-analyzer and teamwork-task-creator)
+
+Fix: rename the second mapping section to "Agent Knowledge Sources (Uses Skills)" and renumber the skills list.
+
+---
+
+### 7. `agents-and-skills.md` — verbose skill examples duplicate category pages
+
+Skills 1–14 are documented with long fake chat transcripts (~600 lines). These duplicate what `docs/commands/` category pages already cover. Skills added later (pr-create, pr-review, design workflow, etc.) are only in the table at the bottom.
+
+**Recommended approach:** Strip the verbose individual skill sections. Keep:
+- The agent architecture description (valuable, not duplicated elsewhere)
+- Both agent mapping tables (with drupalorg agents added)
+- The skills reference table at the bottom
+- The "How to Use" and "Skill Activation Tips" sections (brief, useful)
+
+This takes the page from ~816 lines to ~200–250 lines without losing anything that isn't already documented in a better place.
+
+---
+
+### 8. `agents-and-skills.md` — "Disabling Skills" section is incomplete
+
+Lines 795–802 show empty code blocks and don't describe a real mechanism. Either document the real mechanism or remove the section.
+
+---
+
+## Prioritized Work
+
+| Priority | Change | File | Effort |
+|---|---|---|---|
+| P0 | Add drupalorg specialists to agent tables | `agents-and-skills.md` | Small |
+| P1 | Remove hardcoded counts from docs | `wordpress-skills.md`, `testing.md` | Tiny |
+| P1 | Fix BATS hardcoded count assertions | `tests/test-plugin.bats` | Small |
+| P1 | Fix self-referential tip text | `commands/overview.md` | Tiny |
+| P1 | Fix broken links | `wordpress-skills.md` | Tiny |
+| P1 | Fix duplicate heading + skill numbering | `agents-and-skills.md` | Tiny |
+| P2 | Strip verbose skill examples, keep table + architecture | `agents-and-skills.md` | Medium |
+| P2 | Remove or fix "Disabling Skills" section | `agents-and-skills.md` | Tiny |
+
+---
+
+## What Does NOT Need Changing
+
+- `docs/commands/*.md` — all category pages are accurate and up-to-date
+- `docs/drupal-contribution.md` and `drupal-contribution-skills.md` — comprehensive and correct
+- `docs/index.md` — accurate feature list
+- `docs/reference/agent-skills-reference.md` — external Anthropic skills context, useful
+- All `skills/*/SKILL.md` files — not in scope (this is doc-layer only)
+- All `agents/*/AGENT.md` files — not in scope

--- a/skills/accessibility-audit/SKILL.md
+++ b/skills/accessibility-audit/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: accessibility-audit
 description: Comprehensive WCAG 2.1 Level AA accessibility audit for Drupal and WordPress projects. Spawns accessibility-specialist for full site analysis. Invoke when user runs /audit-a11y, requests a full accessibility audit, needs a WCAG compliance report, or asks for comprehensive accessibility analysis across pages or modules. Supports --quick, --standard, --comprehensive depth modes and scope/format flags.
-disable-model-invocation: true
 ---
 
 # Accessibility Audit

--- a/skills/devops-setup/SKILL.md
+++ b/skills/devops-setup/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: devops-setup
-description: Automate Kanopi's complete Drupal/Pantheon DevOps setup for a new project. Invoke when user explicitly asks to set up DevOps for a new project, onboard a Pantheon site to Kanopi's CI/CD pipeline, or uses /devops-setup. This is an irreversible multi-system setup requiring explicit user confirmation at each phase. Creates GitHub repos, configures Pantheon services, and makes code changes.
-disable-model-invocation: true
+description: Automate Kanopi's complete Drupal/Pantheon DevOps setup for a new project. Invoke when user wants to set up DevOps for a new project, onboard a Pantheon site to Kanopi's CI/CD pipeline, or uses /devops-setup. This is an irreversible multi-system setup requiring explicit user confirmation at each phase. Creates GitHub repos, configures Pantheon services, and makes code changes.
 ---
 
 # DevOps Setup

--- a/skills/live-site-audit/SKILL.md
+++ b/skills/live-site-audit/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: live-site-audit
 description: Comprehensive live site audit orchestrating performance, accessibility, security, and code quality specialists in parallel. Invoke when user runs /audit-live-site, requests a comprehensive site health assessment, needs a full multi-dimensional audit, or wants a unified audit report with health score and remediation roadmap. Generates audit-live-site-YYYY-MM-DD-HHMM.md report file.
-disable-model-invocation: true
 ---
 
 # Live Site Audit

--- a/skills/performance-audit/SKILL.md
+++ b/skills/performance-audit/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: performance-audit
 description: Comprehensive performance analysis and Core Web Vitals optimization for Drupal and WordPress projects. Spawns performance-specialist for full analysis. Invoke when user runs /audit-perf, requests a full performance audit, needs Core Web Vitals analysis (LCP, INP, CLS), or asks for comprehensive performance assessment. Supports --quick, --standard, --comprehensive depth modes and scope/format/target flags.
-disable-model-invocation: true
 ---
 
 # Performance Audit

--- a/skills/pr-create/SKILL.md
+++ b/skills/pr-create/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pr-create
-description: Generate a PR description and create a GitHub pull request. Invoke when user explicitly asks to create a pull request, says "create a PR", "submit a PR", "open a pull request", or uses /pr-create. Requires user confirmation before creating the PR (irreversible GitHub action). Supports ticket numbers and --concise mode.
-disable-model-invocation: true
+description: Generate a PR description and create a GitHub pull request. Invoke when user wants to create a pull request, says "create a PR", "submit a PR", "open a pull request", or uses /pr-create. Requires user confirmation before creating the PR (irreversible GitHub action). Supports ticket numbers and --concise mode.
 ---
 
 # PR Create

--- a/skills/pr-release/SKILL.md
+++ b/skills/pr-release/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pr-release
 description: Generate changelog entries, a deployment checklist, and update a release PR description. Invoke when user asks to prepare a release, generate a changelog, create a deployment checklist, or uses /pr-release. Requires user confirmation before updating the PR (modifies publicly visible content). Supports version numbers and focus areas (changelog/deploy/update).
-disable-model-invocation: true
 ---
 
 # PR Release

--- a/skills/quality-audit/SKILL.md
+++ b/skills/quality-audit/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: quality-audit
 description: Comprehensive code quality analysis and technical debt assessment for Drupal and WordPress projects. Spawns code-quality-specialist for full analysis. Invoke when user runs /quality-analyze, requests a full code quality audit, needs technical debt assessment, or asks for comprehensive code quality analysis. Supports --quick, --standard, --comprehensive depth modes and scope/format/threshold flags.
-disable-model-invocation: true
 ---
 
 # Quality Audit

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: security-audit
 description: Comprehensive OWASP Top 10 security vulnerability scanning and compliance reporting for Drupal and WordPress. Spawns security-specialist for full analysis. Invoke when user runs /audit-security, requests a full security audit, needs OWASP compliance review, or asks for comprehensive vulnerability scanning. Supports --quick, --standard, --comprehensive depth modes and scope/format/severity flags.
-disable-model-invocation: true
 ---
 
 # Security Audit

--- a/skills/strategist-site-audit/SKILL.md
+++ b/skills/strategist-site-audit/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: strategist-site-audit
 description: Strategist-focused site audit for discovery and pre-discovery. Given a site URL and optional qualitative research data, navigates the site via CoWork, audits against all 21 UX Laws from lawsofux.com, reviews content hierarchy, synthesises qualitative data, runs Lighthouse, and produces two deliverables — a Project Knowledge Summary (Markdown for Claude Desktop Projects) and a polished, iterable HTML Artifact for client sharing. Use when a strategist, UX lead, or PM asks for a discovery audit, UX laws audit, content hierarchy review, pre-discovery site review, "audit this site for strategy", "strategist audit", "UX audit", or pastes a site URL with discovery context. Not for developer audits — use accessibility-audit, performance-audit, or live-site-audit for those.
-disable-model-invocation: true
 ---
 
 # Strategist Site Audit

--- a/tests/test-plugin.bats
+++ b/tests/test-plugin.bats
@@ -841,22 +841,6 @@ setup() {
 }
 
 # ==============================================================================
-# CLAUDE CODE INVOCATION POLICY TESTS
-# ==============================================================================
-
-@test "skills with openai.yaml also have disable-model-invocation in SKILL.md" {
-  for yaml_file in skills/*/agents/openai.yaml; do
-    [ -f "$yaml_file" ] || continue
-    skill_dir=$(basename "$(dirname "$(dirname "$yaml_file")")")
-    skill_file="skills/$skill_dir/SKILL.md"
-    if ! grep -q "^disable-model-invocation: true" "$skill_file"; then
-      echo "$skill_file has openai.yaml but missing disable-model-invocation: true"
-      return 1
-    fi
-  done
-}
-
-# ==============================================================================
 # CODEX TOML AGENT TESTS
 # ==============================================================================
 


### PR DESCRIPTION
## Description

- [x] Was AI used in this pull request?

> As a CMS Cultivator user, I need the audit/PR/devops skills to activate from natural language (not just explicit `/command`), so Claude can offer them in context without me remembering the command name.

Removes `disable-model-invocation: true` from nine skills so they become model-invocable, loosens the trigger wording on `devops-setup` and `pr-create` to match, and drops the now-obsolete BATS test that enforced the flag. All skills with real side effects still gate those actions behind explicit user confirmation in their own workflows. Also adds the docs-audit-and-consistency plan that scopes the broader cleanup.

## Acceptance Criteria

* The nine skills (`accessibility-audit`, `live-site-audit`, `performance-audit`, `quality-audit`, `security-audit`, `strategist-site-audit`, `devops-setup`, `pr-create`, `pr-release`) no longer carry `disable-model-invocation: true`.
* `devops-setup` and `pr-create` descriptions read "wants to" rather than "explicitly asks to", with side-effect confirmation language intact.
* The `disable-model-invocation`/`openai.yaml` enforcement test is removed; `validate-frontmatter.sh` and all BATS tests pass.

## Assumptions

* Targets `1.x` (active branch; `main` is stale at v0.9.1).
* The plan file describes a broader cleanup (missing agent docs, hardcoded-count removal, stale references) than this PR implements — it documents follow-up work, not all of it is done here.
* Scoped independently of PR #44 (worktree-manager); no overlap.

## Steps to Validate

1. `./scripts/validate-frontmatter.sh` -> 0 errors.
2. `bats tests/test-plugin.bats` -> all pass.
3. `grep -rl "disable-model-invocation" skills/` -> the nine skills above are gone from the results.

## Affected URL

N/A (plugin metadata + documentation only)

## Deploy Notes

None — no runtime/CMS changes.