### PR TITLE
feat(delivery-record): expand activity_type to the full lifecycle set (v1.6.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cms-cultivator",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Agent Skills and specialist agents for Drupal and WordPress. PR workflows, accessibility / performance / security / quality audits, design-to-code (Figma → blocks/paragraphs), FRD generation with story points, CSV export, strategist UX audits, PM workflows (triage, meeting prep, heartbeats, QA), Drupal.org contribution, and Drupal/Pantheon DevOps. Skills use MCP servers (Teamwork, Slack, Gmail, Fathom, CoWork, GitHub) directly from the main session.",
   "author": {
     "name": "Kanopi Studios",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cms-cultivator",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Agent Skills and specialist agents for Drupal and WordPress. Works in Claude Code, Claude Desktop, and OpenAI Codex.",
   "author": {
     "name": "Kanopi Studios",

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ composer.lock
 
 # Claude
 .claude/settings.local.json
+.claude/worktrees/
 
 # mkdocs
 /site*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-07-07
+
+### Added
+- **Delivery Record** — seven additional `activity_type` values covering the rest of the AI-workflow lifecycle: `design`, `qa`, `launch`, `deployment`, `devops`, `project-setup`, and `ongoing-improvement`. Each ships a schema `if/then` branch, a `checks/<activity_type>.json` sub-schema, a validated `examples/*.md` fixture, and a skill body template. The existing seven values are unchanged (additive, backward-compatible within v1). Enum now totals 14.
+
+### Changed
+- `skills/delivery-record` now **indexes records by posting a comment** on the project's Teamwork "Delivery Records" notebook instead of appending to the notebook body — notebooks have no append operation, so commenting avoids clobbering existing content and keeps a per-record audit trail.
+- `tests/test-delivery-record.bats` derives the activity-type list from the schema enum (parity checks against `checks/`, examples, and templates) rather than hardcoding the count, so the suite grows with the spec.
+- Fixed repository links in the Delivery Record docs/spec (and `docs/testing.md`) to point at the `1.x` branch (were `main`), and removed links to the private `kanopi/ai-workflows` repo.
+- `.gitignore` now excludes `.claude/worktrees/`.
+
 ## [1.5.0] - 2026-06-30
 
 ### Added

--- a/docs/commands/delivery-record.md
+++ b/docs/commands/delivery-record.md
@@ -5,9 +5,7 @@ markdown file per significant AI-assisted output. A record proves the work was
 reviewed by a *named human* and ran through Kanopi's workflow.
 
 The schema is canonical in the repository at
-[`spec/delivery-record/v1/`](../spec/delivery-record/v1.md); the narrative
-rationale lives in
-[`kanopi/ai-workflows`](https://github.com/kanopi/ai-workflows/blob/main/src/content/delivery-record.md).
+[`spec/delivery-record/v1/`](../spec/delivery-record/v1.md).
 
 ---
 
@@ -29,9 +27,9 @@ Draft a Delivery Record, require a named reviewer and checkpoint notes, write th
 file, and index it in Teamwork.
 
 !!! warning "Side effects"
-    Writes a markdown file (repo or Drive), appends to the project's Teamwork
-    "Delivery Records" notebook, and links the record from the PR. **Refuses to
-    write without a named reviewer and both checkpoint notes.**
+    Writes a markdown file (repo or Drive), posts an index comment on the
+    project's Teamwork "Delivery Records" notebook, and links the record from the
+    PR. **Refuses to write without a named reviewer and both checkpoint notes.**
 
 ### Usage
 
@@ -59,8 +57,8 @@ file, and index it in Teamwork.
    and Checkpoint 2 (final) notes. A bare "LGTM" fails.
 5. Writes the file: `docs/delivery-records/PR-<n>-<slug>.md` (code) or Drive
    `/Delivery Records/YYYY-MM-DD-<slug>.md` (non-code).
-6. Indexes the record in the Teamwork "Delivery Records" notebook (asks before
-   creating the notebook).
+6. Indexes the record by posting a comment on the Teamwork "Delivery Records"
+   notebook (asks before creating the notebook).
 7. For code, links the record from the PR description.
 
 ---
@@ -83,4 +81,5 @@ Read-only. See the [verify command page](delivery-record-verify.md).
   per-PR artifact that follows.
 - **`commit-message-generator`** — appends the per-commit `Assisted-by:` trailer
   that complements the per-PR record.
-- **`teamwork-integrator`** — locates and updates the Delivery Records notebook.
+- **`teamwork-integrator`** — locates the Delivery Records notebook and posts the
+  index comment.

--- a/docs/commands/overview.md
+++ b/docs/commands/overview.md
@@ -34,7 +34,7 @@ Per-output attestation: one schema-typed, human-signed markdown file per signifi
 
 | Skill | Description |
 |-------|-------------|
-| `delivery-record` | Draft a Delivery Record (code, FRD, audit, discovery, design-handoff, strategy, client-comm); refuses to write without a named reviewer + checkpoint notes; writes the file and indexes it in Teamwork |
+| `delivery-record` | Draft a Delivery Record (code, FRD, audit, discovery, design-handoff, strategy, client-comm, design, qa, launch, deployment, devops, project-setup, ongoing-improvement); refuses to write without a named reviewer + checkpoint notes; writes the file and indexes it in Teamwork |
 | `delivery-record-verify` | Validate a record against the schema and the threshold rule (read-only, CI-friendly; supports `--strict`) |
 
 ---

--- a/docs/spec/delivery-record/v1.md
+++ b/docs/spec/delivery-record/v1.md
@@ -8,9 +8,7 @@ predicate_type: https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1
 ```
 
 The machine-readable schema is canonical in the repository at
-[`spec/delivery-record/v1/`](https://github.com/kanopi/cms-cultivator/tree/main/spec/delivery-record/v1).
-The narrative rationale lives in
-[`kanopi/ai-workflows` → The Delivery Record](https://github.com/kanopi/ai-workflows/blob/main/src/content/delivery-record.md).
+[`spec/delivery-record/v1/`](https://github.com/kanopi/cms-cultivator/tree/1.x/spec/delivery-record/v1).
 
 !!! note "AI drafts, a named human signs"
     A passive "AI was used" disclosure is not enough. Every Delivery Record names
@@ -32,7 +30,7 @@ prep, status notes, throwaway spikes, or brainstorming.
 | Field | Required | Notes |
 |-------|----------|-------|
 | `predicate_type` | yes | Must match `https://kanopi.github.io/cms-cultivator/spec/delivery-record/v<n>`. |
-| `activity_type` | yes | One of `code`, `frd`, `audit`, `discovery`, `design-handoff`, `strategy`, `client-comm`. |
+| `activity_type` | yes | One of `code`, `frd`, `audit`, `discovery`, `design-handoff`, `strategy`, `client-comm`, `design`, `qa`, `launch`, `deployment`, `devops`, `project-setup`, `ongoing-improvement`. |
 | `subject` | yes | Object with `kind` (`pr`/`document`/`report`/`figma`/`message`) and `title`; optional `ref`, `sha`. |
 | `ticket` | no | Project ticket reference. |
 | `scope` | no | One of `feature`, `fix`, `chore`, `milestone`, `launch`, `deliverable`. |
@@ -54,6 +52,13 @@ evidence. Each activity requires exactly these keys:
 | `design-handoff` | document | `goals_kpis`, `audiences`, `journeys`, `figma_urls`, `cd_review` | Strategist, Designer, Tech Lead |
 | `strategy` | document | `sources_grounded`, `recommendations_defensible`, `alternatives_considered` | Strategist, Account |
 | `client-comm` | message | `facts_verified`, `tone_reviewed`, `no_unauthorized_commitments` | PM, Account |
+| `design` | figma | `brand_alignment`, `design_system`, `accessibility_review`, `stakeholder_review` | Designer, Creative Director |
+| `qa` | report | `acceptance_criteria`, `test_coverage`, `regressions_checked`, `evidence_captured` | QA, Tech Lead |
+| `launch` | document | `prelaunch_audits`, `rollback_plan`, `dns_ssl_verified`, `stakeholder_signoff` | Tech Lead, PM, Account |
+| `deployment` | report | `release_notes`, `backup_taken`, `migrations_verified`, `smoke_test` | Developer, Tech Lead |
+| `devops` | pr | `change_documented`, `tested_lower_env`, `secrets_handled`, `rollback_plan` | DevOps, Tech Lead |
+| `project-setup` | document | `context_accurate`, `sources_verified`, `access_confirmed`, `stakeholder_review` | PM, Tech Lead |
+| `ongoing-improvement` | report | `metrics_reviewed`, `findings_verified`, `recommendations_prioritized`, `stakeholder_review` | Tech Lead, PM |
 
 Each check group is an object. Leaf values are a status (`pass` / `fail` / `n/a`)
 or an evidence string such as a CI run URL or a reviewer note.
@@ -83,7 +88,7 @@ Any JSON Schema 2020-12 validator works against `schema.json` directly.
 
 `v1` is the floor. Additive, backward-compatible changes land in place; breaking
 changes ship as a new `v2/` directory so old records keep validating. See the
-[versioning policy](https://github.com/kanopi/cms-cultivator/blob/main/spec/delivery-record/VERSIONING.md).
+[versioning policy](https://github.com/kanopi/cms-cultivator/blob/1.x/spec/delivery-record/VERSIONING.md).
 
 ## Related
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -181,7 +181,7 @@ Tests run automatically via GitHub Actions on:
 - Pull requests
 - Manual workflow dispatch
 
-See [`.github/workflows/test.yml`](https://github.com/kanopi/cms-cultivator/blob/main/.github/workflows/test.yml) for the complete CI/CD configuration.
+See [`.github/workflows/test.yml`](https://github.com/kanopi/cms-cultivator/blob/1.x/.github/workflows/test.yml) for the complete CI/CD configuration.
 
 ### GitHub Actions Jobs
 
@@ -314,7 +314,7 @@ pip install zensical
 - [BATS Documentation](https://bats-core.readthedocs.io/)
 - [BATS GitHub Repository](https://github.com/bats-core/bats-core)
 - [Test Anything Protocol (TAP)](https://testanything.org/)
-- [GitHub Actions Workflows](https://github.com/kanopi/cms-cultivator/tree/main/.github/workflows)
+- [GitHub Actions Workflows](https://github.com/kanopi/cms-cultivator/tree/1.x/.github/workflows)
 
 ---
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -449,7 +449,7 @@ Detailed instructions for Claude on how to execute this skill...
 ### 51. delivery-record
 
 **Triggers**: "create a delivery record", "generate a delivery record for this PR/FRD/audit", end of a unit of work, "/delivery-record"
-**Purpose**: Draft a schema-typed, human-signed Delivery Record for a significant AI-assisted output (code, FRD, audit, discovery, design-handoff, strategy, client-comm). Refuses to write without a named reviewer and both checkpoint notes, writes to `docs/delivery-records/` (code) or Drive (non-code), and indexes the record in the project's Teamwork "Delivery Records" notebook.
+**Purpose**: Draft a schema-typed, human-signed Delivery Record for a significant AI-assisted output (code, FRD, audit, discovery, design-handoff, strategy, client-comm, design, qa, launch, deployment, devops, project-setup, ongoing-improvement). Refuses to write without a named reviewer and both checkpoint notes, writes to `docs/delivery-records/` (code) or Drive (non-code), and indexes the record by commenting on the project's Teamwork "Delivery Records" notebook.
 **Spec**: [spec/delivery-record/v1/](../spec/delivery-record/v1/README.md)
 **Related Skills**: pr-create, commit-message-generator, teamwork-integrator, delivery-record-verify
 

--- a/skills/delivery-record/SKILL.md
+++ b/skills/delivery-record/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: delivery-record
 description: |
-  Generate a Delivery Record for a significant AI-assisted output (PR, FRD,
-  audit, discovery deliverable, design handoff, strategy doc, or client
-  communication). Refuses to write without a named human reviewer and the two
+  Generate a Delivery Record for a significant AI-assisted output — code (PR),
+  FRD, audit, discovery, design-handoff, strategy, client-comm, design, QA,
+  launch, deployment, devops, project-setup, or ongoing-improvement. Refuses to
+  write without a named human reviewer and the two
   checkpoint notes. Writes to docs/delivery-records/ in a repo or to Drive in
   Claude Desktop, and indexes the result in the project's Teamwork "Delivery
   Records" notebook. Invoke at the end of a unit of work, after /pr-create for
@@ -18,8 +19,7 @@ main session runs this skill directly; no orchestrator agent is involved.
 
 The record proves a piece of AI-assisted work was reviewed by a **named human**
 and ran through Kanopi's workflow. The schema is canonical in this repo at
-[`spec/delivery-record/v1/`](../../spec/delivery-record/v1/README.md); the
-narrative rationale lives in [`kanopi/ai-workflows`](https://github.com/kanopi/ai-workflows/blob/main/src/content/delivery-record.md).
+[`spec/delivery-record/v1/`](../../spec/delivery-record/v1/README.md).
 
 ## ⚠️ Side Effect Warning
 
@@ -27,7 +27,7 @@ narrative rationale lives in [`kanopi/ai-workflows`](https://github.com/kanopi/a
 
 - Writes a markdown file to `docs/delivery-records/` in the repo (code) or to the
   client's Drive (non-code).
-- Appends an index line to the project's "Delivery Records" Teamwork notebook
+- Posts an index comment on the project's "Delivery Records" Teamwork notebook
   (and, with your confirmation, creates that notebook if it is missing).
 - For code records, amends the open PR description with a link to the record.
 
@@ -83,6 +83,20 @@ Pull what the chosen activity needs:
   Teamwork comments tagged to the same epic.
 - **client-comm**: ask for the Teamwork message URL; pull the thread; pull the
   matching Fathom transcript if a call is referenced.
+- **design**: ask for the Figma file URL and the design brief; note which
+  components are reused vs new.
+- **qa**: ask for the QA task and multidev URL; pull the acceptance criteria and
+  the captured screenshots (pairs with `qa-validation-checklist` / `browser-validator`).
+- **launch**: ask for the launch notebook/checklist; gather the pre-launch audit
+  report paths and the DNS/SSL cutover and rollback plans.
+- **deployment**: the release tag, the generated release notes, and confirmation
+  that a backup was taken and migrations ran clean.
+- **devops**: the PR for the infra/environment change and the lower-environment
+  test results; confirm no secrets landed in the repo.
+- **project-setup**: the `CLAUDE.md` / onboarding brief and the SOW; confirm which
+  documented commands were verified against a fresh checkout.
+- **ongoing-improvement**: the metrics source (CWV, uptime, error logs) and the
+  report file; note the sample size.
 
 ### 3. Draft the record
 
@@ -140,7 +154,10 @@ After writing, re-run the validator on the final file and report the result.
 - If it does not exist, **confirm with the user before creating it** (do not create
   silently). If the user declines, skip indexing and tell them the record was
   written but not indexed.
-- Append a one-line entry:
+- **Post the index entry as a comment on the notebook** (Teamwork's
+  `create_comment` against the notebook). Do **not** rewrite the notebook body —
+  notebooks have no append operation, so commenting avoids clobbering existing
+  content and keeps a clean, per-record audit trail. Use this one-line format:
 
   ```
   YYYY-MM-DD · <activity_type> · <title> · <link>
@@ -167,8 +184,8 @@ waiver/justification (threshold) rule are all defined in
 - **No `gh` CLI** → ask the user for the PR number, SHA, and CI status, then
   proceed; print the `gh pr edit` command for the PR link in step 7 instead of
   running it.
-- **No Teamwork MCP** → write the file, then tell the user to add the index line
-  to the Delivery Records notebook manually (provide the exact line).
+- **No Teamwork MCP** → write the file, then tell the user to post the index
+  comment on the Delivery Records notebook manually (provide the exact line).
 - **No Drive MCP (non-code)** → abort the write per step 5 and print the draft.
 
 ## Related skills
@@ -179,4 +196,5 @@ waiver/justification (threshold) rule are all defined in
   complements the per-PR record.
 - **delivery-record-verify** — validate a record against the schema and the
   threshold rule.
-- **teamwork-integrator** — locate and update the Delivery Records notebook.
+- **teamwork-integrator** — locate the Delivery Records notebook and post the
+  index comment.

--- a/skills/delivery-record/templates/deployment.md
+++ b/skills/delivery-record/templates/deployment.md
@@ -1,0 +1,47 @@
+---
+predicate_type: https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1
+activity_type: deployment
+subject:
+  kind: report
+  ref: "<Release tag / deploy URL>"
+  title: "<Deploy vX.Y.Z to production>"
+ticket: <TICKET>            # optional
+scope: milestone            # feature | fix | chore | milestone | launch | deliverable
+assisted_by:
+  models: [<model-id>]
+  skills: [<skills used>]
+checks:
+  release_notes:       { generated: <pass|fail|n/a>, reviewed: <pass|fail|n/a> }
+  backup_taken:        { database: <pass|fail|n/a>, files: <pass|fail|n/a> }
+  migrations_verified: { config_import: <pass|fail|n/a>, updb: <pass|fail|n/a> }
+  smoke_test:          { homepage: <pass|fail|n/a>, login: <pass|fail|n/a> }
+sign_off:
+  produced_by: "@<author> <YYYY-MM-DD>"
+  reviewed_by: ""           # REQUIRED — filled at the human checkpoint
+  # approved_by: "@<client> <YYYY-MM-DD>"   # required when scope is launch or deliverable
+---
+
+<!-- Justify every `n/a` in one line near the top. A `fail` needs a `## Waiver` section. -->
+
+## What changed
+
+One paragraph: what shipped in this release and how the notes were assembled.
+
+## What the AI produced
+
+Which skill generated the release notes (e.g. commit-message-generator). Note that
+the deploy command is posted for a human to run — the skill does not deploy.
+
+## What the human verified
+
+Checkpoint 1 (plan approval): <release scope confirmed; backup ran before cutover>.
+Checkpoint 2 (final approval): <migrations applied cleanly; smoke test across the
+critical paths>.
+
+## Issues found and resolved
+
+- ...
+
+## Deferred or known risks
+
+- ... (owner + ticket link)

--- a/skills/delivery-record/templates/design.md
+++ b/skills/delivery-record/templates/design.md
@@ -1,0 +1,47 @@
+---
+predicate_type: https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1
+activity_type: design
+subject:
+  kind: figma
+  ref: "<Figma file URL>"
+  title: "<Deliverable title>"
+ticket: <TICKET>            # optional
+scope: deliverable          # feature | fix | chore | milestone | launch | deliverable
+assisted_by:
+  models: [<model-id>]
+  skills: [<skills used>]
+checks:
+  brand_alignment:      { logo_usage: <pass|fail|n/a>, color_tokens: <pass|fail|n/a>, type_scale: <pass|fail|n/a> }
+  design_system:        { components_reused: <pass|fail|n/a>, new_components_documented: <pass|fail|n/a> }
+  accessibility_review: { contrast: <pass|fail|n/a>, target_sizes: <pass|fail|n/a>, focus_states: <pass|fail|n/a> }
+  stakeholder_review:   { reviewed: "<approved by @reviewer>", client: <pass|fail|n/a> }
+sign_off:
+  produced_by: "@<author> <YYYY-MM-DD>"
+  reviewed_by: ""           # REQUIRED — filled at the human checkpoint
+  approved_by: "@<client> <YYYY-MM-DD>"   # required when scope is launch or deliverable
+---
+
+<!-- Justify every `n/a` in one line near the top. A `fail` needs a `## Waiver` section. -->
+
+## What changed
+
+One paragraph: what was designed (mood board, design system, hi-fi comps) and how
+it was delivered.
+
+## What the AI produced
+
+Which skill(s) ran (e.g. design-analyzer) and what they extracted or flagged.
+
+## What the human verified
+
+Checkpoint 1 (plan approval): <the direction confirmed before building comps>.
+Checkpoint 2 (final approval): <brand alignment, component reuse, and AA contrast
+verified beyond the automated checks>.
+
+## Issues found and resolved
+
+- ...
+
+## Deferred or known risks
+
+- ... (owner + ticket link)

--- a/skills/delivery-record/templates/devops.md
+++ b/skills/delivery-record/templates/devops.md
@@ -1,0 +1,49 @@
+---
+predicate_type: https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1
+activity_type: devops
+subject:
+  kind: pr
+  ref: "<org/repo#PR>"
+  sha: <short-sha>
+  title: "<Infra / environment change>"
+ticket: <TICKET>            # optional
+scope: chore                # feature | fix | chore | milestone | launch | deliverable
+assisted_by:
+  models: [<model-id>]
+  skills: [<skills used>]
+checks:
+  change_documented: { readme_updated: <pass|fail|n/a>, runbook: <pass|fail|n/a> }
+  tested_lower_env:  { multidev: <pass|fail|n/a>, ci_pipeline: <pass|fail|n/a> }
+  secrets_handled:   { no_secrets_in_repo: <pass|fail|n/a>, env_vars_documented: <pass|fail|n/a> }
+  rollback_plan:     { documented: <pass|fail|n/a>, revert_tested: <pass|fail|n/a> }
+sign_off:
+  produced_by: "@<author> <YYYY-MM-DD>"
+  reviewed_by: ""           # REQUIRED — filled at the human checkpoint
+  # approved_by: "@<client> <YYYY-MM-DD>"   # required when scope is launch or deliverable
+---
+
+<!-- Justify every `n/a` in one line near the top. A `fail` needs a `## Waiver` section. -->
+
+## What changed
+
+One paragraph plus a bullet list of the config/infra files touched. Note whether
+application code paths change.
+
+## What the AI produced
+
+Which skill(s) ran (e.g. code-standards-checker) and any hosting commands that were
+printed for a human to run rather than executed.
+
+## What the human verified
+
+Checkpoint 1 (plan approval): <backend choice and lower-environment test plan confirmed>.
+Checkpoint 2 (final approval): <no secrets in the repo; change tested in a lower
+environment; revert path tested>.
+
+## Issues found and resolved
+
+- ...
+
+## Deferred or known risks
+
+- ... (owner + ticket link)

--- a/skills/delivery-record/templates/launch.md
+++ b/skills/delivery-record/templates/launch.md
@@ -1,0 +1,47 @@
+---
+predicate_type: https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1
+activity_type: launch
+subject:
+  kind: document
+  ref: "<Launch notebook / doc URL>"
+  title: "<Launch readiness — site>"
+ticket: <TICKET>            # optional
+scope: launch               # feature | fix | chore | milestone | launch | deliverable
+assisted_by:
+  models: [<model-id>]
+  skills: [<skills used>]
+checks:
+  prelaunch_audits:    { a11y: <pass|fail|n/a>, performance: <pass|fail|n/a>, seo: <pass|fail|n/a>, security: <pass|fail|n/a> }
+  rollback_plan:       { documented: <pass|fail|n/a>, tested: <pass|fail|n/a> }
+  dns_ssl_verified:    { dns_cutover: <pass|fail|n/a>, ssl_cert: <pass|fail|n/a>, redirects: <pass|fail|n/a> }
+  stakeholder_signoff: { techlead: <pass|fail|n/a>, pm: <pass|fail|n/a>, client: "<approved by @client>" }
+sign_off:
+  produced_by: "@<author> <YYYY-MM-DD>"
+  reviewed_by: ""           # REQUIRED — filled at the human checkpoint
+  approved_by: "@<client> <YYYY-MM-DD>"   # required when scope is launch or deliverable
+---
+
+<!-- Justify every `n/a` in one line near the top. A `fail` needs a `## Waiver` section. -->
+
+## What changed
+
+One paragraph: the launch scope, the cutover plan, and the rollback procedure.
+
+## What the AI produced
+
+Which audit skills ran (e.g. performance-analyzer, structured-data-analyzer) and
+where the reports live.
+
+## What the human verified
+
+Checkpoint 1 (plan approval): <cutover window and stakeholder list confirmed>.
+Checkpoint 2 (final approval): <rollback tested; redirect map complete; go-live
+approved>.
+
+## Issues found and resolved
+
+- ...
+
+## Deferred or known risks
+
+- ... (owner + ticket link)

--- a/skills/delivery-record/templates/ongoing-improvement.md
+++ b/skills/delivery-record/templates/ongoing-improvement.md
@@ -1,0 +1,48 @@
+---
+predicate_type: https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1
+activity_type: ongoing-improvement
+subject:
+  kind: report
+  ref: "<Report / notebook URL>"
+  title: "<Site health review — site>"
+ticket: <TICKET>            # optional
+scope: deliverable          # feature | fix | chore | milestone | launch | deliverable
+assisted_by:
+  models: [<model-id>]
+  skills: [<skills used>]
+checks:
+  metrics_reviewed:            { core_web_vitals: <pass|fail|n/a>, uptime: <pass|fail|n/a>, error_rate: <pass|fail|n/a> }
+  findings_verified:           { reproduced: <pass|fail|n/a>, sample_size: "<n templates>" }
+  recommendations_prioritized: { ranked: <pass|fail|n/a>, effort_estimated: <pass|fail|n/a> }
+  stakeholder_review:          { reviewed: "<approved by @pm>", techlead: <pass|fail|n/a> }
+sign_off:
+  produced_by: "@<author> <YYYY-MM-DD>"
+  reviewed_by: ""           # REQUIRED — filled at the human checkpoint
+  approved_by: "@<client> <YYYY-MM-DD>"   # required when scope is launch or deliverable
+---
+
+<!-- Justify every `n/a` in one line near the top. A `fail` needs a `## Waiver` section. -->
+
+## What changed
+
+One paragraph: the review window, the metrics summarized, and the recommendation
+output.
+
+## What the AI produced
+
+Which skill(s) ran (e.g. performance-analyzer, coverage-analyzer) and what they
+surfaced.
+
+## What the human verified
+
+Checkpoint 1 (plan approval): <metrics window and sampled templates confirmed>.
+Checkpoint 2 (final approval): <top findings reproduced; effort estimates and
+priority order confirmed>.
+
+## Issues found and resolved
+
+- ...
+
+## Deferred or known risks
+
+- ... (owner + ticket link)

--- a/skills/delivery-record/templates/project-setup.md
+++ b/skills/delivery-record/templates/project-setup.md
@@ -1,0 +1,48 @@
+---
+predicate_type: https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1
+activity_type: project-setup
+subject:
+  kind: document
+  ref: "<repo/CLAUDE.md or brief URL>"
+  title: "<Project context — CLAUDE.md / onboarding brief>"
+ticket: <TICKET>            # optional
+scope: deliverable          # feature | fix | chore | milestone | launch | deliverable
+assisted_by:
+  models: [<model-id>]
+  skills: [<skills used>]
+checks:
+  context_accurate:   { stack_verified: <pass|fail|n/a>, commands_verified: <pass|fail|n/a> }
+  sources_verified:   { sow_reviewed: <pass|fail|n/a>, repo_inspected: <pass|fail|n/a> }
+  access_confirmed:   { hosting: <pass|fail|n/a>, teamwork: <pass|fail|n/a>, drive: <pass|fail|n/a> }
+  stakeholder_review: { reviewed: "<approved by @pm>", techlead: <pass|fail|n/a> }
+sign_off:
+  produced_by: "@<author> <YYYY-MM-DD>"
+  reviewed_by: ""           # REQUIRED — filled at the human checkpoint
+  approved_by: "@<client> <YYYY-MM-DD>"   # required when scope is launch or deliverable
+---
+
+<!-- Justify every `n/a` in one line near the top. A `fail` needs a `## Waiver` section. -->
+
+## What changed
+
+One paragraph: what project context was established (CLAUDE.md, onboarding brief)
+and what it points to.
+
+## What the AI produced
+
+Which skill drafted it (e.g. documentation-generator) and from what sources (repo
+inspection, SOW).
+
+## What the human verified
+
+Checkpoint 1 (plan approval): <sections and source documents confirmed>.
+Checkpoint 2 (final approval): <every documented command run against a fresh
+checkout; access confirmed>.
+
+## Issues found and resolved
+
+- ...
+
+## Deferred or known risks
+
+- ... (owner + ticket link)

--- a/skills/delivery-record/templates/qa.md
+++ b/skills/delivery-record/templates/qa.md
@@ -1,0 +1,47 @@
+---
+predicate_type: https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1
+activity_type: qa
+subject:
+  kind: report
+  ref: "<Teamwork task URL>"
+  title: "<QA — feature (TICKET)>"
+ticket: <TICKET>            # optional
+scope: feature              # feature | fix | chore | milestone | launch | deliverable
+assisted_by:
+  models: [<model-id>]
+  skills: [<skills used>]
+checks:
+  acceptance_criteria: { all_met: <pass|fail|n/a>, notes: "<n of n criteria validated>" }
+  test_coverage:       { functional: <pass|fail|n/a>, responsive: <pass|fail|n/a>, cross_browser: <pass|fail|n/a> }
+  regressions_checked: { adjacent_pages: <pass|fail|n/a> }
+  evidence_captured:   { screenshots: <pass|fail|n/a>, multidev_url: "<preview URL>" }
+sign_off:
+  produced_by: "@<author> <YYYY-MM-DD>"
+  reviewed_by: ""           # REQUIRED — filled at the human checkpoint
+  # approved_by: "@<client> <YYYY-MM-DD>"   # required when scope is launch or deliverable
+---
+
+<!-- Justify every `n/a` in one line near the top. A `fail` needs a `## Waiver` section. -->
+
+## What changed
+
+One paragraph: what was validated and against which acceptance criteria.
+
+## What the AI produced
+
+Which skill(s) generated the checklist and drove the browser (e.g.
+qa-validation-checklist, browser-validator), and what evidence was captured.
+
+## What the human verified
+
+Checkpoint 1 (plan approval): <the validation steps matched the acceptance criteria>.
+Checkpoint 2 (final approval): <screenshots and regression pass reviewed; console
+checked>.
+
+## Issues found and resolved
+
+- ...
+
+## Deferred or known risks
+
+- ... (owner + ticket link)

--- a/spec/delivery-record/v1/README.md
+++ b/spec/delivery-record/v1/README.md
@@ -4,8 +4,7 @@ The canonical, machine-readable schema for a **Delivery Record**: one
 schema-typed, human-signed markdown file per significant AI-assisted output.
 This directory is the authoritative source. The human-readable face of the spec
 lives on the docs site at
-<https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1/>, and the
-narrative rationale lives in [`kanopi/ai-workflows` → `/delivery-record`](https://github.com/kanopi/ai-workflows/blob/main/src/content/delivery-record.md).
+<https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1/>.
 
 > **AI drafts the record. A named human reviews, edits, and signs.** A passive
 > "AI was used" disclosure is not enough — the record names the reviewer.
@@ -25,7 +24,7 @@ Only the **front-matter** is validated. The prose body is unstructured by design
 | Field | Required | Notes |
 | --- | --- | --- |
 | `predicate_type` | yes | Must match `https://kanopi.github.io/cms-cultivator/spec/delivery-record/v<n>`. |
-| `activity_type` | yes | One of `code`, `frd`, `audit`, `discovery`, `design-handoff`, `strategy`, `client-comm`. |
+| `activity_type` | yes | One of `code`, `frd`, `audit`, `discovery`, `design-handoff`, `strategy`, `client-comm`, `design`, `qa`, `launch`, `deployment`, `devops`, `project-setup`, `ongoing-improvement`. |
 | `subject` | yes | Object with `kind` (`pr`/`document`/`report`/`figma`/`message`) and `title`; optional `ref`, `sha`. |
 | `ticket` | no | Project ticket reference. |
 | `scope` | no | One of `feature`, `fix`, `chore`, `milestone`, `launch`, `deliverable`. |
@@ -47,6 +46,13 @@ evidence. Each `checks/<activity_type>.json` requires exactly these keys:
 | `design-handoff` | document | `goals_kpis`, `audiences`, `journeys`, `figma_urls`, `cd_review` | Strategist, Designer, Tech Lead |
 | `strategy` | document | `sources_grounded`, `recommendations_defensible`, `alternatives_considered` | Strategist, Account |
 | `client-comm` | message | `facts_verified`, `tone_reviewed`, `no_unauthorized_commitments` | PM, Account |
+| `design` | figma | `brand_alignment`, `design_system`, `accessibility_review`, `stakeholder_review` | Designer, Creative Director |
+| `qa` | report | `acceptance_criteria`, `test_coverage`, `regressions_checked`, `evidence_captured` | QA, Tech Lead |
+| `launch` | document | `prelaunch_audits`, `rollback_plan`, `dns_ssl_verified`, `stakeholder_signoff` | Tech Lead, PM, Account |
+| `deployment` | report | `release_notes`, `backup_taken`, `migrations_verified`, `smoke_test` | Developer, Tech Lead |
+| `devops` | pr | `change_documented`, `tested_lower_env`, `secrets_handled`, `rollback_plan` | DevOps, Tech Lead |
+| `project-setup` | document | `context_accurate`, `sources_verified`, `access_confirmed`, `stakeholder_review` | PM, Tech Lead |
+| `ongoing-improvement` | report | `metrics_reviewed`, `findings_verified`, `recommendations_prioritized`, `stakeholder_review` | Tech Lead, PM |
 
 Each check group is an object. Leaf values are a status (`pass` / `fail` / `n/a`)
 or an evidence string such as a CI run URL or a reviewer note

--- a/spec/delivery-record/v1/checks/deployment.json
+++ b/spec/delivery-record/v1/checks/deployment.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1/checks/deployment.json",
+  "title": "Delivery Record checks — deployment",
+  "description": "Constrains the `checks` block for activity_type: deployment. Subject kind: report. Sign-off roles: Developer, Tech Lead.",
+  "type": "object",
+  "required": ["release_notes", "backup_taken", "migrations_verified", "smoke_test"],
+  "additionalProperties": { "$ref": "#/$defs/checkGroup" },
+  "properties": {
+    "release_notes": { "$ref": "#/$defs/checkGroup" },
+    "backup_taken": { "$ref": "#/$defs/checkGroup" },
+    "migrations_verified": { "$ref": "#/$defs/checkGroup" },
+    "smoke_test": { "$ref": "#/$defs/checkGroup" }
+  },
+  "$defs": {
+    "checkGroup": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "anyOf": [
+          { "type": "string" },
+          { "type": "number" },
+          { "type": "boolean" }
+        ]
+      }
+    }
+  }
+}

--- a/spec/delivery-record/v1/checks/design.json
+++ b/spec/delivery-record/v1/checks/design.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1/checks/design.json",
+  "title": "Delivery Record checks — design",
+  "description": "Constrains the `checks` block for activity_type: design. Subject kind: figma. Sign-off roles: Designer, Creative Director.",
+  "type": "object",
+  "required": ["brand_alignment", "design_system", "accessibility_review", "stakeholder_review"],
+  "additionalProperties": { "$ref": "#/$defs/checkGroup" },
+  "properties": {
+    "brand_alignment": { "$ref": "#/$defs/checkGroup" },
+    "design_system": { "$ref": "#/$defs/checkGroup" },
+    "accessibility_review": { "$ref": "#/$defs/checkGroup" },
+    "stakeholder_review": { "$ref": "#/$defs/checkGroup" }
+  },
+  "$defs": {
+    "checkGroup": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "anyOf": [
+          { "type": "string" },
+          { "type": "number" },
+          { "type": "boolean" }
+        ]
+      }
+    }
+  }
+}

--- a/spec/delivery-record/v1/checks/devops.json
+++ b/spec/delivery-record/v1/checks/devops.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1/checks/devops.json",
+  "title": "Delivery Record checks — devops",
+  "description": "Constrains the `checks` block for activity_type: devops. Subject kind: pr. Sign-off roles: DevOps, Tech Lead.",
+  "type": "object",
+  "required": ["change_documented", "tested_lower_env", "secrets_handled", "rollback_plan"],
+  "additionalProperties": { "$ref": "#/$defs/checkGroup" },
+  "properties": {
+    "change_documented": { "$ref": "#/$defs/checkGroup" },
+    "tested_lower_env": { "$ref": "#/$defs/checkGroup" },
+    "secrets_handled": { "$ref": "#/$defs/checkGroup" },
+    "rollback_plan": { "$ref": "#/$defs/checkGroup" }
+  },
+  "$defs": {
+    "checkGroup": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "anyOf": [
+          { "type": "string" },
+          { "type": "number" },
+          { "type": "boolean" }
+        ]
+      }
+    }
+  }
+}

--- a/spec/delivery-record/v1/checks/launch.json
+++ b/spec/delivery-record/v1/checks/launch.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1/checks/launch.json",
+  "title": "Delivery Record checks — launch",
+  "description": "Constrains the `checks` block for activity_type: launch. Subject kind: document. Sign-off roles: Tech Lead, PM, Account.",
+  "type": "object",
+  "required": ["prelaunch_audits", "rollback_plan", "dns_ssl_verified", "stakeholder_signoff"],
+  "additionalProperties": { "$ref": "#/$defs/checkGroup" },
+  "properties": {
+    "prelaunch_audits": { "$ref": "#/$defs/checkGroup" },
+    "rollback_plan": { "$ref": "#/$defs/checkGroup" },
+    "dns_ssl_verified": { "$ref": "#/$defs/checkGroup" },
+    "stakeholder_signoff": { "$ref": "#/$defs/checkGroup" }
+  },
+  "$defs": {
+    "checkGroup": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "anyOf": [
+          { "type": "string" },
+          { "type": "number" },
+          { "type": "boolean" }
+        ]
+      }
+    }
+  }
+}

--- a/spec/delivery-record/v1/checks/ongoing-improvement.json
+++ b/spec/delivery-record/v1/checks/ongoing-improvement.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1/checks/ongoing-improvement.json",
+  "title": "Delivery Record checks — ongoing-improvement",
+  "description": "Constrains the `checks` block for activity_type: ongoing-improvement. Subject kind: report. Sign-off roles: Tech Lead, PM.",
+  "type": "object",
+  "required": ["metrics_reviewed", "findings_verified", "recommendations_prioritized", "stakeholder_review"],
+  "additionalProperties": { "$ref": "#/$defs/checkGroup" },
+  "properties": {
+    "metrics_reviewed": { "$ref": "#/$defs/checkGroup" },
+    "findings_verified": { "$ref": "#/$defs/checkGroup" },
+    "recommendations_prioritized": { "$ref": "#/$defs/checkGroup" },
+    "stakeholder_review": { "$ref": "#/$defs/checkGroup" }
+  },
+  "$defs": {
+    "checkGroup": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "anyOf": [
+          { "type": "string" },
+          { "type": "number" },
+          { "type": "boolean" }
+        ]
+      }
+    }
+  }
+}

--- a/spec/delivery-record/v1/checks/project-setup.json
+++ b/spec/delivery-record/v1/checks/project-setup.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1/checks/project-setup.json",
+  "title": "Delivery Record checks — project-setup",
+  "description": "Constrains the `checks` block for activity_type: project-setup. Subject kind: document. Sign-off roles: PM, Tech Lead.",
+  "type": "object",
+  "required": ["context_accurate", "sources_verified", "access_confirmed", "stakeholder_review"],
+  "additionalProperties": { "$ref": "#/$defs/checkGroup" },
+  "properties": {
+    "context_accurate": { "$ref": "#/$defs/checkGroup" },
+    "sources_verified": { "$ref": "#/$defs/checkGroup" },
+    "access_confirmed": { "$ref": "#/$defs/checkGroup" },
+    "stakeholder_review": { "$ref": "#/$defs/checkGroup" }
+  },
+  "$defs": {
+    "checkGroup": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "anyOf": [
+          { "type": "string" },
+          { "type": "number" },
+          { "type": "boolean" }
+        ]
+      }
+    }
+  }
+}

--- a/spec/delivery-record/v1/checks/qa.json
+++ b/spec/delivery-record/v1/checks/qa.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1/checks/qa.json",
+  "title": "Delivery Record checks — qa",
+  "description": "Constrains the `checks` block for activity_type: qa. Subject kind: report. Sign-off roles: QA, Tech Lead.",
+  "type": "object",
+  "required": ["acceptance_criteria", "test_coverage", "regressions_checked", "evidence_captured"],
+  "additionalProperties": { "$ref": "#/$defs/checkGroup" },
+  "properties": {
+    "acceptance_criteria": { "$ref": "#/$defs/checkGroup" },
+    "test_coverage": { "$ref": "#/$defs/checkGroup" },
+    "regressions_checked": { "$ref": "#/$defs/checkGroup" },
+    "evidence_captured": { "$ref": "#/$defs/checkGroup" }
+  },
+  "$defs": {
+    "checkGroup": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "anyOf": [
+          { "type": "string" },
+          { "type": "number" },
+          { "type": "boolean" }
+        ]
+      }
+    }
+  }
+}

--- a/spec/delivery-record/v1/examples/deployment.md
+++ b/spec/delivery-record/v1/examples/deployment.md
@@ -1,0 +1,48 @@
+---
+predicate_type: https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1
+activity_type: deployment
+subject:
+  kind: report
+  ref: "https://github.com/kanopi/example/releases/tag/v2.4.0"
+  title: "Deploy v2.4.0 to production"
+ticket: PROJ-450
+scope: milestone
+assisted_by:
+  models: [claude-opus-4-8]
+  skills: [commit-message-generator]
+checks:
+  release_notes:       { generated: pass, reviewed: pass }
+  backup_taken:        { database: pass, files: pass }
+  migrations_verified: { config_import: pass, updb: pass }
+  smoke_test:          { homepage: pass, login: pass, checkout: pass }
+sign_off:
+  produced_by: "@sam 2026-06-30"
+  reviewed_by: "@techlead 2026-06-30"
+---
+
+## What changed
+
+Production deploy of release v2.4.0: the breadcrumb component, two bug fixes, and
+a config change for the new content type. Release notes generated from the merged
+PR titles since v2.3.0.
+
+## What the AI produced
+
+`commit-message-generator` assembled the release notes from the conventional-commit
+history. The deploy command was posted for a human to run — the skill does not
+deploy on its own.
+
+## What the human verified
+
+Checkpoint 1 (plan approval): @sam confirmed the release scope and the backup step
+ran before cutover.
+Checkpoint 2 (final approval): @techlead verified the config import and database
+updates applied cleanly, then ran the smoke test across the three critical paths.
+
+## Issues found and resolved
+
+- Config import warned about a stale block placement; re-exported and re-ran clean.
+
+## Deferred or known risks
+
+- None.

--- a/spec/delivery-record/v1/examples/design.md
+++ b/spec/delivery-record/v1/examples/design.md
@@ -1,0 +1,50 @@
+---
+predicate_type: https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1
+activity_type: design
+subject:
+  kind: figma
+  ref: "https://www.figma.com/file/abc123/Homepage-Redesign"
+  title: "Homepage hi-fidelity comps"
+ticket: PROJ-210
+scope: deliverable
+assisted_by:
+  models: [claude-opus-4-8]
+  skills: [design-analyzer]
+checks:
+  brand_alignment:      { logo_usage: pass, color_tokens: pass, type_scale: pass }
+  design_system:        { components_reused: pass, new_components_documented: pass }
+  accessibility_review: { contrast: pass, target_sizes: pass, focus_states: pass }
+  stakeholder_review:   { reviewed: "approved by @creative-director", client: pass }
+sign_off:
+  produced_by: "@dana 2026-06-28"
+  reviewed_by: "@creative-director 2026-06-28"
+  approved_by: "@client 2026-06-29"
+---
+
+## What changed
+
+Hi-fidelity homepage comps built on the approved design system: hero, feature
+grid, testimonial band, and footer. Delivered as a Figma file with named layers
+and component instances.
+
+## What the AI produced
+
+`design-analyzer` extracted the token set (colors, type scale, spacing) from the
+existing design system and flagged three spots where the draft diverged from the
+brand palette.
+
+## What the human verified
+
+Checkpoint 1 (plan approval): @dana confirmed the layout direction against the
+content strategy before building comps.
+Checkpoint 2 (final approval): @creative-director verified brand alignment,
+component reuse, and AA contrast on every text-over-image treatment; @client
+approved the direction.
+
+## Issues found and resolved
+
+- Testimonial text over the photo failed AA; added a scrim to reach 4.6:1.
+
+## Deferred or known risks
+
+- None.

--- a/spec/delivery-record/v1/examples/devops.md
+++ b/spec/delivery-record/v1/examples/devops.md
@@ -1,0 +1,53 @@
+---
+predicate_type: https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1
+activity_type: devops
+subject:
+  kind: pr
+  ref: "kanopi/example#512"
+  sha: a1b2c3d
+  title: "Add Redis object cache to CI and Pantheon config"
+ticket: PROJ-480
+scope: chore
+assisted_by:
+  models: [claude-opus-4-8]
+  skills: [code-standards-checker]
+checks:
+  change_documented: { readme_updated: pass, runbook: pass }
+  tested_lower_env:  { multidev: pass, ci_pipeline: pass }
+  secrets_handled:   { no_secrets_in_repo: pass, env_vars_documented: pass }
+  rollback_plan:     { documented: pass, revert_tested: pass }
+sign_off:
+  produced_by: "@sam 2026-06-29"
+  reviewed_by: "@devops-lead 2026-06-29"
+---
+
+## What changed
+
+Enables the Redis object cache for the project: adds the DDEV service, the
+CircleCI config, and the Pantheon settings wiring. No application code paths
+change.
+
+- `.ddev/docker-compose.redis.yaml`
+- `.circleci/config.yml`
+- `web/sites/default/settings.pantheon.php`
+
+## What the AI produced
+
+`code-standards-checker` linted the settings changes. The Terminus commands to
+enable the Pantheon Redis add-on were printed for a human to run — the skill does
+not touch the hosting account directly.
+
+## What the human verified
+
+Checkpoint 1 (plan approval): @sam confirmed the cache backend choice and the
+lower-environment test plan.
+Checkpoint 2 (final approval): @devops-lead verified no secrets landed in the repo,
+confirmed the cache hit on the multidev, and tested the revert path.
+
+## Issues found and resolved
+
+- Initial config committed a placeholder auth token; removed and moved to an env var.
+
+## Deferred or known risks
+
+- None.

--- a/spec/delivery-record/v1/examples/launch.md
+++ b/spec/delivery-record/v1/examples/launch.md
@@ -1,0 +1,51 @@
+---
+predicate_type: https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1
+activity_type: launch
+subject:
+  kind: document
+  ref: "https://kanopi.teamwork.com/app/notebooks/5501"
+  title: "Launch readiness — example.com relaunch"
+ticket: PROJ-900
+scope: launch
+assisted_by:
+  models: [claude-opus-4-8]
+  skills: [performance-analyzer, structured-data-analyzer]
+checks:
+  prelaunch_audits:    { a11y: pass, performance: pass, seo: pass, security: pass }
+  rollback_plan:       { documented: pass, tested: pass }
+  dns_ssl_verified:    { dns_cutover: pass, ssl_cert: pass, redirects: pass }
+  stakeholder_signoff: { techlead: pass, pm: pass, client: "approved by @client" }
+sign_off:
+  produced_by: "@dana 2026-07-01"
+  reviewed_by: "@techlead 2026-07-01"
+  approved_by: "@client 2026-07-01"
+---
+
+## What changed
+
+Launch readiness record for the example.com relaunch: the pre-launch audit
+results, the DNS/SSL cutover plan, and the rollback procedure, consolidated for
+go-live sign-off.
+
+## What the AI produced
+
+`performance-analyzer` confirmed Core Web Vitals against the launch budget;
+`structured-data-analyzer` validated the JSON-LD on the key templates. Both
+reports are linked from the launch notebook.
+
+## What the human verified
+
+Checkpoint 1 (plan approval): @dana confirmed the cutover window and the
+stakeholder list.
+Checkpoint 2 (final approval): @techlead verified the rollback plan was tested
+against a staging snapshot and that the redirect map covered every legacy URL;
+@client approved go-live.
+
+## Issues found and resolved
+
+- Two legacy URLs were missing from the redirect map; added before sign-off.
+
+## Deferred or known risks
+
+- Third-party review widget loads async; monitored for the first 48 hours (owner
+  @dana, PROJ-901).

--- a/spec/delivery-record/v1/examples/ongoing-improvement.md
+++ b/spec/delivery-record/v1/examples/ongoing-improvement.md
@@ -1,0 +1,51 @@
+---
+predicate_type: https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1
+activity_type: ongoing-improvement
+subject:
+  kind: report
+  ref: "https://kanopi.teamwork.com/app/notebooks/6110"
+  title: "Q2 site health review — example.com"
+ticket: PROJ-770
+scope: deliverable
+assisted_by:
+  models: [claude-opus-4-8]
+  skills: [performance-analyzer, coverage-analyzer]
+checks:
+  metrics_reviewed:            { core_web_vitals: pass, uptime: pass, error_rate: pass }
+  findings_verified:           { reproduced: pass, sample_size: "12 templates" }
+  recommendations_prioritized: { ranked: pass, effort_estimated: pass }
+  stakeholder_review:          { reviewed: "approved by @pm", techlead: pass }
+sign_off:
+  produced_by: "@dana 2026-07-02"
+  reviewed_by: "@techlead 2026-07-02"
+  approved_by: "@pm 2026-07-02"
+---
+
+## What changed
+
+Quarterly site-health review for example.com: Core Web Vitals trend, error-rate
+and uptime summary, and a prioritized list of improvement recommendations for the
+next engagement block.
+
+## What the AI produced
+
+`performance-analyzer` pulled the CWV trend across the top templates;
+`coverage-analyzer` flagged three untested code paths that recur in error logs.
+Findings were compiled into a ranked recommendation list.
+
+## What the human verified
+
+Checkpoint 1 (plan approval): @dana confirmed the metrics window and the templates
+to sample.
+Checkpoint 2 (final approval): @techlead reproduced the top three findings and
+confirmed the effort estimates were realistic; @pm approved the priority order.
+
+## Issues found and resolved
+
+- One "regression" was a measurement artifact from a synthetic-test change; dropped
+  from the findings after verification.
+
+## Deferred or known risks
+
+- INP on the search results template is borderline; scheduled for the next block
+  (owner @techlead, PROJ-771).

--- a/spec/delivery-record/v1/examples/project-setup.md
+++ b/spec/delivery-record/v1/examples/project-setup.md
@@ -1,0 +1,51 @@
+---
+predicate_type: https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1
+activity_type: project-setup
+subject:
+  kind: document
+  ref: "kanopi/example/CLAUDE.md"
+  title: "Project context — CLAUDE.md and onboarding brief"
+ticket: PROJ-001
+scope: deliverable
+assisted_by:
+  models: [claude-opus-4-8]
+  skills: [documentation-generator]
+checks:
+  context_accurate:   { stack_verified: pass, commands_verified: pass }
+  sources_verified:   { sow_reviewed: pass, repo_inspected: pass }
+  access_confirmed:   { hosting: pass, teamwork: pass, drive: pass }
+  stakeholder_review: { reviewed: "approved by @pm", techlead: pass }
+sign_off:
+  produced_by: "@dana 2026-06-24"
+  reviewed_by: "@techlead 2026-06-24"
+  approved_by: "@pm 2026-06-24"
+---
+
+## What changed
+
+Established the shared project context: a `CLAUDE.md` documenting the stack,
+DDEV/Composer commands, and coding standards, plus an onboarding brief pointing
+to the SOW, hosting, and Teamwork.
+
+## What the AI produced
+
+`documentation-generator` drafted `CLAUDE.md` from an inspection of the repo
+(composer.json, theme tooling, CI config) and the SOW, then flagged commands it
+could not verify.
+
+## What the human verified
+
+Checkpoint 1 (plan approval): @dana confirmed the sections to include and the
+source documents.
+Checkpoint 2 (final approval): @techlead ran every documented command against a
+fresh checkout to confirm accuracy; @pm approved the onboarding brief and
+confirmed access to hosting, Teamwork, and Drive.
+
+## Issues found and resolved
+
+- Draft listed a `npm run test` script that does not exist; removed after the
+  command-verification pass.
+
+## Deferred or known risks
+
+- None.

--- a/spec/delivery-record/v1/examples/qa.md
+++ b/spec/delivery-record/v1/examples/qa.md
@@ -1,0 +1,47 @@
+---
+predicate_type: https://kanopi.github.io/cms-cultivator/spec/delivery-record/v1
+activity_type: qa
+subject:
+  kind: report
+  ref: "https://kanopi.teamwork.com/app/tasks/8123"
+  title: "QA — breadcrumb component (PROJ-123)"
+ticket: PROJ-123
+scope: feature
+assisted_by:
+  models: [claude-opus-4-8]
+  skills: [qa-validation-checklist, browser-validator]
+checks:
+  acceptance_criteria: { all_met: pass, notes: "3 of 3 criteria validated" }
+  test_coverage:       { functional: pass, responsive: pass, cross_browser: pass }
+  regressions_checked: { adjacent_pages: pass, existing_menu: pass }
+  evidence_captured:   { screenshots: pass, multidev_url: "https://pr-123-example.pantheonsite.io" }
+sign_off:
+  produced_by: "@quinn 2026-06-26"
+  reviewed_by: "@techlead 2026-06-26"
+---
+
+## What changed
+
+QA validation of the breadcrumb component on the PR multidev before it advances
+to Code Review. Validated against the ticket's acceptance criteria.
+
+## What the AI produced
+
+`qa-validation-checklist` generated the step-by-step validation plan from the
+ticket; `browser-validator` drove the multidev at 320px, 768px, and 1024px and
+captured annotated screenshots.
+
+## What the human verified
+
+Checkpoint 1 (plan approval): @quinn confirmed the validation steps matched the
+acceptance criteria.
+Checkpoint 2 (final approval): @techlead reviewed the screenshots and the
+regression pass on the existing menu trail, and confirmed no console errors.
+
+## Issues found and resolved
+
+- Focus ring was clipped at 320px; logged as a follow-up before merge.
+
+## Deferred or known risks
+
+- None.

--- a/spec/delivery-record/v1/schema.json
+++ b/spec/delivery-record/v1/schema.json
@@ -28,7 +28,14 @@
         "discovery",
         "design-handoff",
         "strategy",
-        "client-comm"
+        "client-comm",
+        "design",
+        "qa",
+        "launch",
+        "deployment",
+        "devops",
+        "project-setup",
+        "ongoing-improvement"
       ]
     },
     "subject": {
@@ -188,6 +195,111 @@
               "facts_verified",
               "tone_reviewed",
               "no_unauthorized_commitments"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "activity_type": { "const": "design" } } },
+      "then": {
+        "properties": {
+          "checks": {
+            "required": [
+              "brand_alignment",
+              "design_system",
+              "accessibility_review",
+              "stakeholder_review"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "activity_type": { "const": "qa" } } },
+      "then": {
+        "properties": {
+          "checks": {
+            "required": [
+              "acceptance_criteria",
+              "test_coverage",
+              "regressions_checked",
+              "evidence_captured"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "activity_type": { "const": "launch" } } },
+      "then": {
+        "properties": {
+          "checks": {
+            "required": [
+              "prelaunch_audits",
+              "rollback_plan",
+              "dns_ssl_verified",
+              "stakeholder_signoff"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "activity_type": { "const": "deployment" } } },
+      "then": {
+        "properties": {
+          "checks": {
+            "required": [
+              "release_notes",
+              "backup_taken",
+              "migrations_verified",
+              "smoke_test"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "activity_type": { "const": "devops" } } },
+      "then": {
+        "properties": {
+          "checks": {
+            "required": [
+              "change_documented",
+              "tested_lower_env",
+              "secrets_handled",
+              "rollback_plan"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "activity_type": { "const": "project-setup" } } },
+      "then": {
+        "properties": {
+          "checks": {
+            "required": [
+              "context_accurate",
+              "sources_verified",
+              "access_confirmed",
+              "stakeholder_review"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "activity_type": { "const": "ongoing-improvement" } } },
+      "then": {
+        "properties": {
+          "checks": {
+            "required": [
+              "metrics_reviewed",
+              "findings_verified",
+              "recommendations_prioritized",
+              "stakeholder_review"
             ]
           }
         }

--- a/tests/test-delivery-record-verify.bats
+++ b/tests/test-delivery-record-verify.bats
@@ -44,7 +44,10 @@ have_validator() {
   run python3 "$VALIDATOR" "$VSPEC"/examples/*.md
   echo "$output"
   [ "$status" -eq 0 ]
-  echo "$output" | grep -q "7 passing"
+  # Derive the expected count from the number of example files, so the assertion
+  # grows with the spec instead of hardcoding a number.
+  count=$(ls "$VSPEC"/examples/*.md | wc -l | tr -d ' ')
+  echo "$output" | grep -q "$count passing"
 }
 
 @test "verify fails for a hand-crafted broken record" {

--- a/tests/test-delivery-record.bats
+++ b/tests/test-delivery-record.bats
@@ -15,7 +15,19 @@ have_validator() {
   command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml, jsonschema' >/dev/null 2>&1
 }
 
-ACTIVITY_TYPES=(code frd audit discovery design-handoff strategy client-comm)
+# The activity-type list is derived from the schema enum so tests grow with the
+# spec instead of hardcoding a count. Call inside a test (after setup cd's to root).
+activity_types() {
+  jq -r '.properties.activity_type.enum[]' "$VSPEC/schema.json"
+}
+
+# The example filename for an activity type (code is the one that differs).
+example_file() {
+  case "$1" in
+    code) echo "$VSPEC/examples/code-pr.md" ;;
+    *)    echo "$VSPEC/examples/$1.md" ;;
+  esac
+}
 
 # ==============================================================================
 # SPEC STRUCTURE
@@ -36,8 +48,8 @@ ACTIVITY_TYPES=(code frd audit discovery design-handoff strategy client-comm)
   [ "$status" -eq 0 ]
 }
 
-@test "all seven checks/<activity_type>.json files exist and are valid JSON" {
-  for t in "${ACTIVITY_TYPES[@]}"; do
+@test "a checks/<activity_type>.json file exists and is valid JSON for every activity type" {
+  for t in $(activity_types); do
     [ -f "$VSPEC/checks/$t.json" ] || { echo "missing checks/$t.json"; return 1; }
     run jq empty "$VSPEC/checks/$t.json"
     [ "$status" -eq 0 ] || { echo "invalid JSON in checks/$t.json"; return 1; }
@@ -50,9 +62,13 @@ ACTIVITY_TYPES=(code frd audit discovery design-handoff strategy client-comm)
   echo "$output" | grep -q 'kanopi\\\.github\\\.io/cms-cultivator/spec/delivery-record'
 }
 
-@test "activity_type enum lists exactly the seven activity types" {
-  run jq -c '.properties.activity_type.enum | sort' "$VSPEC/schema.json"
-  [ "$output" = '["audit","client-comm","code","design-handoff","discovery","frd","strategy"]' ]
+@test "activity_type enum matches the checks/ files exactly (parity, no drift)" {
+  enum=$(jq -r '.properties.activity_type.enum[]' "$VSPEC/schema.json" | sort | tr '\n' ' ')
+  files=$(for f in "$VSPEC"/checks/*.json; do basename "$f" .json; done | sort | tr '\n' ' ')
+  if [ "$enum" != "$files" ]; then
+    echo "enum ($enum) != checks files ($files)"
+    return 1
+  fi
 }
 
 # ==============================================================================
@@ -63,17 +79,25 @@ ACTIVITY_TYPES=(code frd audit discovery design-handoff strategy client-comm)
   # Uses a case statement (not associative arrays) for macOS bash 3.2 support.
   expected_keys() {
     case "$1" in
-      code)           echo '["audits","review","standards","tests"]' ;;
-      frd)            echo '["completeness","hour_total_vs_cap","sow_alignment","stakeholder_review"]' ;;
-      audit)          echo '["findings_verified","methodology","sample_size","severity_rubric"]' ;;
-      discovery)      echo '["bias_check","sample_size","sources_cited","stakeholder_review"]' ;;
-      design-handoff) echo '["audiences","cd_review","figma_urls","goals_kpis","journeys"]' ;;
-      strategy)       echo '["alternatives_considered","recommendations_defensible","sources_grounded"]' ;;
-      client-comm)    echo '["facts_verified","no_unauthorized_commitments","tone_reviewed"]' ;;
+      code)                echo '["audits","review","standards","tests"]' ;;
+      frd)                 echo '["completeness","hour_total_vs_cap","sow_alignment","stakeholder_review"]' ;;
+      audit)               echo '["findings_verified","methodology","sample_size","severity_rubric"]' ;;
+      discovery)           echo '["bias_check","sample_size","sources_cited","stakeholder_review"]' ;;
+      design-handoff)      echo '["audiences","cd_review","figma_urls","goals_kpis","journeys"]' ;;
+      strategy)            echo '["alternatives_considered","recommendations_defensible","sources_grounded"]' ;;
+      client-comm)         echo '["facts_verified","no_unauthorized_commitments","tone_reviewed"]' ;;
+      design)              echo '["accessibility_review","brand_alignment","design_system","stakeholder_review"]' ;;
+      qa)                  echo '["acceptance_criteria","evidence_captured","regressions_checked","test_coverage"]' ;;
+      launch)              echo '["dns_ssl_verified","prelaunch_audits","rollback_plan","stakeholder_signoff"]' ;;
+      deployment)          echo '["backup_taken","migrations_verified","release_notes","smoke_test"]' ;;
+      devops)              echo '["change_documented","rollback_plan","secrets_handled","tested_lower_env"]' ;;
+      project-setup)       echo '["access_confirmed","context_accurate","sources_verified","stakeholder_review"]' ;;
+      ongoing-improvement) echo '["findings_verified","metrics_reviewed","recommendations_prioritized","stakeholder_review"]' ;;
+      *)                   echo "UNMAPPED:$1" ;;
     esac
   }
 
-  for t in "${ACTIVITY_TYPES[@]}"; do
+  for t in $(activity_types); do
     got=$(jq -c '.required | sort' "$VSPEC/checks/$t.json")
     want=$(expected_keys "$t")
     if [ "$got" != "$want" ]; then
@@ -84,7 +108,7 @@ ACTIVITY_TYPES=(code frd audit discovery design-handoff strategy client-comm)
 }
 
 @test "schema.json if/then branches stay in sync with checks/<activity_type>.json" {
-  for t in "${ACTIVITY_TYPES[@]}"; do
+  for t in $(activity_types); do
     from_schema=$(jq -c --arg t "$t" \
       '.allOf[] | select(.if.properties.activity_type.const==$t) | .then.properties.checks.required | sort' \
       "$VSPEC/schema.json")
@@ -101,13 +125,10 @@ ACTIVITY_TYPES=(code frd audit discovery design-handoff strategy client-comm)
 # ==============================================================================
 
 @test "an example record exists for every activity type" {
-  [ -f "$VSPEC/examples/code-pr.md" ]
-  [ -f "$VSPEC/examples/frd.md" ]
-  [ -f "$VSPEC/examples/audit.md" ]
-  [ -f "$VSPEC/examples/discovery.md" ]
-  [ -f "$VSPEC/examples/design-handoff.md" ]
-  [ -f "$VSPEC/examples/strategy.md" ]
-  [ -f "$VSPEC/examples/client-comm.md" ]
+  for t in $(activity_types); do
+    f=$(example_file "$t")
+    [ -f "$f" ] || { echo "missing example for $t ($f)"; return 1; }
+  done
 }
 
 @test "spec validates against itself — every example passes (strict)" {
@@ -155,7 +176,7 @@ ACTIVITY_TYPES=(code frd audit discovery design-handoff strategy client-comm)
 }
 
 @test "delivery-record ships a body template for every activity type" {
-  for t in "${ACTIVITY_TYPES[@]}"; do
+  for t in $(activity_types); do
     [ -f "skills/delivery-record/templates/$t.md" ] || { echo "missing template $t.md"; return 1; }
   done
 }


### PR DESCRIPTION
## Summary

Expands the **Delivery Record** `activity_type` enum from 7 to **14** values so it covers the full AI-workflow lifecycle, plus a set of docs/link fixes and a Teamwork indexing change. Additive and backward-compatible within `v1` — the existing 7 values are unchanged.

### Added — 7 new activity types
`design`, `qa`, `launch`, `deployment`, `devops`, `project-setup`, `ongoing-improvement`. Each ships:
- a `schema.json` `if/then` branch,
- a `checks/<activity_type>.json` sub-schema,
- a strict-passing `examples/*.md` fixture,
- a skill body `templates/*.md`.

### Changed
- `skills/delivery-record` now **indexes records by posting a comment** on the project's Teamwork "Delivery Records" notebook instead of rewriting the notebook body — notebooks have no append operation, so commenting avoids clobbering existing content and keeps a per-record audit trail.
- Fixed repository links in the Delivery Record docs/spec **and** `docs/testing.md` to point at the `1.x` branch (were `main`); removed links to the **private** `kanopi/ai-workflows` repo.
- `tests/test-delivery-record.bats` (and one assertion in `-verify.bats`) now derive the activity-type list/count from the schema enum — parity checks against `checks/`, examples, and templates — instead of hardcoding a count.
- `.gitignore` excludes `.claude/worktrees/`.

### Release
Bumps `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to **1.6.0** and adds the `[1.6.0]` CHANGELOG entry.

## Testing
- `python3 scripts/delivery_record_verify.py --strict spec/delivery-record/v1/examples/*.md` → **14 records · 14 passing**
- `bats tests/test-delivery-record.bats tests/test-delivery-record-verify.bats` → **22/22 passing**
- `./scripts/validate-frontmatter.sh` → clean

- [x] Was AI used in this pull request?