### PR TITLE
Add composer-patch-generator skill; bring README skill roster current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `README.md` — refreshed the Agent Skills roster to list all current skills (grouped by capability) and added curated Key Features sections for Development Workflow, Drupal.org Contribution, and DevOps & Onboarding, plus previously unlisted skills (`gtm-performance-audit`, `structured-data-analyzer`, `drupal-sdc-twig`, `strategic-thinking`).
+- `CLAUDE.md` — the "Adding a New Feature" checklist now requires updating all registry files on every new skill: `CHANGELOG.md` (`[Unreleased]`), `skills/README.md` (append the next number so the count matches the skill-directory count enforced by `tests/test-plugin.bats`), the `docs/agents-and-skills.md` reference table, and the top-level `README.md` roster.
 
 ## [1.6.0] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `skills/composer-patch-generator/SKILL.md` — new skill for generating and maintaining CI-safe patches for Composer-installed packages (Drupal contrib modules, WordPress plugins/packages, PHP libraries) via `cweagans/composer-patches`. Codifies the failure modes that cause "applies locally, fails in CI": use `diff -ruN` (not `git diff`) because CI installs from dist archives with no `.git` so composer-patches falls back to the `patch` command; base the diff on the dist archive (not a git clone) to avoid spurious `LICENSE.txt`/packaging-metadata hunks; never pass `--exclude` to `diff` (it leaks into headers); and exclude the composer-patches-generated `PATCHES.txt` artifact. Covers snapshotting a pristine base, path normalization, wiring `extra.patches` in `composer.json` (ordering, `patchLevel`), handling new files, and verifying via `patch -p1 --dry-run` plus `composer install`. Model-invoked (no command). Registered in `skills/README.md` and the `docs/agents-and-skills.md` reference table.
+
+### Changed
+- `README.md` — refreshed the Agent Skills roster to list all current skills (grouped by capability) and added curated Key Features sections for Development Workflow, Drupal.org Contribution, and DevOps & Onboarding, plus previously unlisted skills (`gtm-performance-audit`, `structured-data-analyzer`, `drupal-sdc-twig`, `strategic-thinking`).
+
 ## [1.6.0] - 2026-07-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,10 +109,11 @@ Skills automatically reference Kanopi-specific tools when available:
    - Include all code examples, patterns, best practices
    - Add Drupal and WordPress examples
 
-2. **Update documentation**:
-   - Add to `docs/agents-and-skills.md`
-   - Update `skills/README.md`
-   - Update README if needed
+2. **Register the skill** (required — update ALL of these on every new skill so the docs, changelog, and tests stay in sync):
+   - Add an `### Added` entry under `[Unreleased]` in `CHANGELOG.md`
+   - Add a numbered entry in `skills/README.md` (the number of `### N.` entries must equal the number of skill directories — `tests/test-plugin.bats` asserts this, so append the next number rather than inserting mid-list)
+   - Add a row to the Skills Reference Table in `docs/agents-and-skills.md`
+   - Add the skill to the Agent Skills roster (and the relevant Key Features section) in the top-level `README.md`
 
 ### Updating Existing Features
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Comprehensive performance, accessibility, and security audits with flexible argu
 - `security-audit` - OWASP Top 10 vulnerability scanning
 - `performance-audit` - Core Web Vitals and optimization
 - `quality-audit` - Code quality and technical debt
+- `gtm-performance-audit` - Google Tag Manager performance impact (Chrome DevTools MCP)
+- `structured-data-analyzer` - JSON-LD / Schema.org structured data for SEO
 - `live-site-audit` - Comprehensive parallel audit (all specialists)
 - `audit-export` - Export audit findings to CSV for project management tools
 - `audit-report` - Generate client-facing executive summaries
@@ -88,6 +90,32 @@ Figma → WordPress blocks, Drupal paragraphs with browser validation.
 - `design-to-wp-block` - Create WordPress block pattern
 - `design-to-drupal-paragraph` - Create Drupal paragraph type
 - `browser-validator` - Validate implementation in Chrome
+- `drupal-sdc-twig` - Best practices for Drupal Single Directory Components (Twig)
+
+### Development Workflow
+Parallel work with git worktrees and safe changes to Composer-managed dependencies.
+
+**Skills:**
+- `worktree-manager` - Create, list, and tear down git worktrees (Kanopi branch conventions, DDEV isolation)
+- `composer-patch-generator` - Generate and maintain CI-safe patches for Composer packages (cweagans/composer-patches)
+
+### Drupal.org Contribution
+Create issues and merge requests on drupal.org from your local environment.
+
+**Skills:**
+- `drupal-contribute` - Full contribution workflow (issue + merge request)
+- `drupal-issue` - Create, update, and comment on drupal.org issues
+- `drupal-mr` - Create merge requests via git.drupalcode.org
+- `drupal-cleanup` - List and clean up cloned drupal.org repositories
+
+### DevOps & Onboarding
+Automate Kanopi's Pantheon DevOps setup for Drupal and WordPress.
+
+**Skills:**
+- `devops-setup` - Drupal/Pantheon DevOps onboarding (DDEV, CircleCI, code quality)
+- `wp-devops-setup` - WordPress/Pantheon DevOps onboarding (wp-pantheon-starter)
+- `wp-plugin-to-private-package` - Convert a premium WordPress plugin into a private Composer package
+- `wp-add-skills` - Install official WordPress agent-skills
 
 ### Documentation
 API docs, user guides, developer documentation, changelogs.
@@ -117,6 +145,7 @@ Strategist-focused discovery audits — not developer audits. Requires CoWork.
 
 **Skills:**
 - `strategist-site-audit` - Audit a site against the 21 UX Laws (lawsofux.com), review content hierarchy, synthesise qualitative data, run Lighthouse, and produce a Project Knowledge Summary (Markdown) plus an iterable client-facing HTML Artifact (CoWork)
+- `strategic-thinking` - Guide decisions through Brené Brown's 5 Cs of Strategic Thinking
 
 **See [docs site](https://kanopi.github.io/cms-cultivator/) for complete skill reference and usage examples.**
 
@@ -144,18 +173,16 @@ PR workflows (`pr-create`, `pr-review`, `pr-release`, `commit-message-generator`
 ### Agent Skills
 
 Model-invoked skills that activate during conversation, across Claude Code, Claude Desktop, and OpenAI Codex:
-- accessibility-checker, security-scanner, performance-analyzer
-- commit-message-generator, test-scaffolding, coverage-analyzer
-- documentation-generator, test-plan-generator, code-standards-checker
-- structured-data-analyzer, design-analyzer, responsive-styling, browser-validator
-- accessibility-audit, performance-audit, security-audit, quality-audit
-- live-site-audit, pr-review, audit-export, audit-report
-- design-to-wp-block, design-to-drupal-paragraph, pr-create, pr-release
-- delivery-record, delivery-record-verify
-- devops-setup, drupal-contribute, drupal-issue, drupal-mr, drupal-cleanup, wp-add-skills
-- frd-generator, story-point-estimator, csv-exporter
-- client-request-triage, pm-meeting-prep, project-heartbeat, qa-review
-- strategist-site-audit
+- **PR & development workflow:** commit-message-generator, pr-create, pr-review, pr-release, worktree-manager, composer-patch-generator
+- **Delivery records:** delivery-record, delivery-record-verify
+- **Code quality & testing:** code-standards-checker, quality-audit, test-scaffolding, test-plan-generator, coverage-analyzer, documentation-generator
+- **Auditing:** accessibility-checker, accessibility-audit, performance-analyzer, performance-audit, security-scanner, security-audit, structured-data-analyzer, gtm-performance-audit, live-site-audit, audit-export, audit-report
+- **Design-to-code:** design-analyzer, design-to-wp-block, design-to-drupal-paragraph, responsive-styling, browser-validator, drupal-sdc-twig
+- **Drupal.org contribution:** drupal-contribute, drupal-issue, drupal-mr, drupal-cleanup, drupalorg-contribution-helper, drupalorg-issue-helper
+- **DevOps & onboarding:** devops-setup, wp-devops-setup, wp-plugin-to-private-package, wp-add-skills
+- **Project planning:** frd-generator, story-point-estimator, csv-exporter
+- **PM workflows:** teamwork-task-creator, teamwork-integrator, teamwork-exporter, client-request-triage, pm-meeting-prep, project-heartbeat, qa-review
+- **Strategy:** strategic-thinking, strategist-site-audit
 
 ### How It Works
 

--- a/docs/agents-and-skills.md
+++ b/docs/agents-and-skills.md
@@ -809,6 +809,7 @@ Don't try to "game" the system—just describe what you need:
 | drupal-sdc-twig | "SDC", "Single Directory Component", "props or slots?", "embed vs include" | Drupal SDC + Twig best practices (props vs slots, attributes, escaping, schema, accessibility) | — |
 | delivery-record | "create a delivery record", "delivery record for this PR/FRD/audit", end of a unit of work | Per-output attestation: draft a schema-typed, human-signed Delivery Record; refuses to write without a named reviewer + checkpoint notes; indexes in Teamwork (runs from the main session) | `delivery-record` |
 | delivery-record-verify | "verify this delivery record", "validate the delivery records" | Validate a record against the `kanopi/delivery-record` schema + threshold rule (read-only, CI-friendly) | `delivery-record-verify` |
+| composer-patch-generator | "composer patch", "patch a contrib module", "cweagans", "diff -ruN", "extra.patches", "applies locally but fails in CI" | CI-safe patches for Composer packages (correct diff -ruN format, dist-archive base, composer.json wiring, verification) | `composer-patch-generator` |
 
 ## Integration with Workflow
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -460,6 +460,11 @@ Detailed instructions for Claude on how to execute this skill...
 **Spec**: [spec/delivery-record/v1/](../spec/delivery-record/v1/README.md)
 **Related Skills**: delivery-record
 
+### 53. composer-patch-generator
+
+**Triggers**: "composer patch", "patch a contrib module", "cweagans", "diff -ruN", "extra.patches", "applies locally but fails in CI"
+**Purpose**: Generate and maintain CI-safe patches for Composer-installed packages (Drupal contrib modules, WordPress plugins/packages, PHP libraries) using `cweagans/composer-patches`. Covers correct `diff -ruN` format (vs `git diff`), basing the diff on the dist archive, wiring `extra.patches` in `composer.json`, handling new files, and verifying with `patch -p1 --dry-run` plus `composer install`.
+
 ## Adding New Skills
 
 To add a new Agent Skill:

--- a/skills/composer-patch-generator/SKILL.md
+++ b/skills/composer-patch-generator/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: composer-patch-generator
+description: Generate and maintain patches for Composer-installed packages (Drupal contrib modules, WordPress packages, PHP libraries) using cweagans/composer-patches. Invoke when the user needs to modify a contrib or vendor package, mentions "composer patch", "patch a module", "patch a contrib module", "cweagans", "diff -ruN", "extra.patches", or needs a package change that applies cleanly in CI. Covers generating diff -ruN patches, handling new files, wiring composer.json, and verifying the patch applies.
+---
+
+# Composer Patch Generator
+
+Generate reliable, CI-safe patches for Composer-managed packages you cannot edit
+directly (Drupal contrib modules, WordPress plugins/packages, PHP libraries).
+
+## Philosophy
+
+Contrib and vendor code is not yours to fork. Patches let you carry a change on
+top of an upstream release, re-apply it on every `composer install`, and drop it
+the moment upstream ships a fix.
+
+### Core Beliefs
+
+1. **Patches are temporary by design** — always describe the change so it can be
+   removed when upstream merges it.
+2. **CI is the source of truth** — a patch that applies locally but fails in CI
+   is a broken patch. Generate for how CI applies, not how your laptop does.
+3. **Minimal surface** — a patch should contain only your delta, never build
+   artifacts, `.git` metadata, or tooling files.
+4. **Never edit `vendor/` or `web/modules/contrib/` directly** — those dirs are
+   git-ignored and rebuilt on install. The patch is the only durable artifact.
+
+## When to Use This Skill
+
+Activate when the user:
+- Wants to change a Composer-installed package (contrib module, plugin, library).
+- Mentions "composer patch", "patch this module", "cweagans", "extra.patches".
+- Says a change "needs to be a patch" or "applies in CI but not locally" (or vice versa).
+- Needs to create, update, or debug an entry under `extra.patches` in `composer.json`.
+
+Do **not** use for changes to custom (first-party) modules/themes — edit those directly.
+
+## Critical Rules (why patches fail in CI)
+
+These are the failure modes that cause "works locally, fails on CI":
+
+1. **Use `diff -ruN`, NOT `git diff`.** `cweagans/composer-patches` tries
+   `git apply` only when the install dir has a `.git` folder. CI installs with
+   `--prefer-dist` (archives, no `.git`), so it falls back to the `patch`
+   command — which cannot parse git headers (`diff --git`, `new file mode
+   100644`, `index abc..def`). `diff -ruN` is universally compatible.
+2. **Base the diff on the dist archive, not a `git clone`.** Drupal.org dist
+   `.zip`/`.tar.gz` files differ from the git repo: they add `LICENSE.txt` and
+   packaging metadata (version/datestamp lines appended to `.info.yml`). CI uses
+   the dist. If you diff against a clone, those files show up as spurious "new
+   file" hunks that fail when `patch` finds them already present.
+3. **Never pass `--exclude` to `diff -ruN`.** It leaks into the header lines
+   (`diff -ruN --ex a/file b/file`) and breaks `patch` parsing. Delete unwanted
+   dirs (`.git`, `node_modules`) *before* diffing instead.
+4. **Exclude tool artifacts.** After a patched install, the package dir contains
+   a `PATCHES.txt` written by composer-patches. Never let it into your diff.
+
+## Workflow
+
+### 1. Identify the package, version, and prior patches
+
+```bash
+# Exact installed version (drives which dist archive to download).
+grep -E "^version|datestamp" web/modules/contrib/<module>/<module>.info.yml
+# Or from the lock file:
+grep -A2 '"name": "drupal/<module>"' composer.lock | head -3
+
+# Any patches already applied (yours must stack cleanly on top of these).
+grep -A6 '"drupal/<module>"' composer.json
+```
+
+### 2. Snapshot a pristine base BEFORE editing
+
+Edit the installed files in place (so you can test live), and diff them against
+a clean snapshot of the *same version*.
+
+```bash
+WORK=/tmp/patch_gen && rm -rf "$WORK" && mkdir -p "$WORK"
+# Preferred base = the dist archive CI will use:
+curl -sL "https://ftp.drupal.org/files/projects/<module>-<version>.zip" -o "$WORK/dist.zip"
+unzip -q "$WORK/dist.zip" -d "$WORK/base_dl"     # -> $WORK/base_dl/<module>
+cp -r "$WORK/base_dl/<module>" "$WORK/base"
+
+# If earlier patches exist, apply them to the base first so your diff is a
+# clean delta ON TOP of them (order matters — composer applies in listed order):
+( cd "$WORK/base" && patch -p1 --no-backup-if-mismatch < /path/to/earlier-patch.patch )
+```
+
+If you cannot download the dist (no network, private package), snapshot the
+current installed dir *before* you edit as the base — acceptable as long as no
+uncommitted edits exist yet and no unpatched files you'll touch differ from dist.
+
+### 3. Make your edits to the installed package
+
+Edit files under `web/modules/contrib/<module>/` (or `vendor/<pkg>/`) directly.
+Run the project's checks on the changed files (e.g. `composer phpcs`,
+`composer phpstan`, unit tests) before generating the patch.
+
+### 4. Generate the patch with `diff -ruN`
+
+```bash
+# Mirror the edited install into a clean "modified" tree (drop noise + artifacts).
+rsync -a --exclude='.git' --exclude='node_modules' \
+  web/modules/contrib/<module>/ "$WORK/modified/"
+rm -f "$WORK/modified/PATCHES.txt"          # composer-patches artifact — never patch it
+rm -rf "$WORK/base/.git" "$WORK/modified/.git"
+
+# Confirm ONLY the files you intended changed:
+diff -qr "$WORK/base" "$WORK/modified"
+
+# Emit the patch, normalizing paths to a/ … b/ (what `patch -p1` expects):
+( cd "$WORK" && diff -ruN base/ modified/ \
+  | sed 's|^--- base/|--- a/|; s|^+++ modified/|+++ b/|; \
+         s|^diff -ruN base/|diff -ruN a/|; s| modified/| b/|' \
+  ) > patches/<module>-<short-description>.patch
+```
+
+New files are handled automatically by `diff -ruN` (uses an epoch timestamp on
+the `---` line), unlike `git diff`'s unparseable `new file mode` header.
+
+### 5. Wire it into `composer.json`
+
+```json
+"extra": {
+    "patches": {
+        "drupal/<module>": {
+            "Short description of the change (link to upstream issue/MR if any)": "patches/<module>-<short-description>.patch"
+        }
+    }
+}
+```
+
+Patches for one package apply in listed order; each must apply on top of the
+previous. If a patch needs a non-default strip level, add
+`"extra": { "patchLevel": { "drupal/<module>": "-p1" } }`.
+
+### 6. Verify (the step that catches CI failures)
+
+```bash
+# a) CI-equivalent dry run on a fresh pristine copy:
+cp -r "$WORK/base_dl/<module>" "$WORK/verify"
+( cd "$WORK/verify" && patch -p1 --dry-run --no-backup-if-mismatch < patches/<module>-<desc>.patch; echo "exit: $?" )
+
+# b) End-to-end through Composer (definitive):
+composer reinstall drupal/<module> --no-interaction
+# NOTE: reinstall deletes the dir then reports "Uninstall failed / not installed".
+# That is a known cweagans quirk — follow with:
+composer install --no-interaction
+# Look for: "Applying patches for drupal/<module>" with no errors.
+```
+
+Both must succeed. Re-run the project's lint/tests once more against the
+freshly patched install to confirm nothing drifted.
+
+## Updating an existing patch
+
+Regenerate against a base that has all *prior* patches applied but not the one
+you are rewriting. The diff then captures the new delta only. Re-verify with the
+full stack applied in order.
+
+## Report Format
+
+When done, summarize:
+
+```
+## Composer Patch: <module>-<description>
+
+- Package: drupal/<module> <version> (dist)
+- Files changed: <list>
+- New files: <list or none>
+- composer.json: entry added under extra.patches["drupal/<module>"]
+- Verified: patch -p1 dry-run ✅ | composer install "Applying patches" ✅
+- Checks: phpcs ✅ | phpstan ✅ | tests ✅
+- Upstream: <issue/MR link, or "none — local customization">
+```
+
+## Common Gotchas
+
+- **Works locally, fails on CI:** almost always `git diff` format or a `.git`
+  dir enabling `git apply` locally. Regenerate with `diff -ruN`.
+- **"Cannot apply patch" on a new file:** the file already exists in dist (you
+  based the diff on a git clone). Rebuild the base from the dist archive.
+- **Lock-file warning after editing `composer.json`:** adding an `extra.patches`
+  entry does not change dependency versions, so no `composer update` is needed;
+  the warning is benign. Only re-lock if you changed a `require`.
+- **Patch silently does nothing:** wrong strip level — set `extra.patchLevel`.
+- **Package dir is git-ignored:** expected. Only the patch file in `patches/`
+  and the `composer.json` entry are committed; the module files are not tracked.
+
+## Example Interactions
+
+```
+You: "I need to fix a bug in the drupal/ai contrib module and it has to survive composer install."
+Claude: "I'll create a composer patch. First, the installed version and any existing
+patches for drupal/ai, then I'll snapshot the pristine dist as the base, apply your
+edit, generate a diff -ruN patch, wire it into extra.patches, and verify it applies
+via composer install."
+```
+
+```
+You: "My patch applies on my machine but the pipeline says 'Cannot apply patch'."
+Claude: "That's the classic git-diff-vs-patch mismatch. CI installs from dist archives
+with no .git dir, so composer-patches falls back to the `patch` command, which can't
+read git headers. Let me regenerate it in diff -ruN format based on the dist archive."
+```
+
+## Resources
+
+- [cweagans/composer-patches](https://github.com/cweagans/composer-patches)
+- [Drupal.org: patch conventions](https://www.drupal.org/docs/develop/git/using-git-to-contribute-to-drupal/creating-a-patch)
+- `patch(1)` and `diff(1)` man pages


### PR DESCRIPTION
## Summary

Adds a new model-invoked skill, **`composer-patch-generator`**, and brings the README skill roster current (targets `1.x`).

The skill captures hard-won practice for patching Composer-managed packages (Drupal contrib, WordPress plugins/packages, PHP libraries) with `cweagans/composer-patches` — specifically the failure modes that make a patch "apply locally but fail in CI."

## New skill: `composer-patch-generator`

Model-invoked (no command), activates on "composer patch", "patch a contrib module", "cweagans", "diff -ruN", "extra.patches", or "applies locally but fails in CI".

Core guidance:
- **Use `diff -ruN`, not `git diff`** — CI installs from dist archives with no `.git`, so composer-patches falls back to the `patch` command, which cannot parse git headers (`diff --git`, `new file mode`, `index …`).
- **Base the diff on the dist archive**, not a git clone, to avoid spurious `LICENSE.txt` / packaging-metadata hunks.
- **Never pass `--exclude` to `diff`** (it leaks into headers); delete `.git`/`node_modules` before diffing.
- **Exclude the composer-patches `PATCHES.txt` artifact.**
- Snapshot a pristine base, normalize paths to `a/`…`b/`, wire `extra.patches` (ordering + `patchLevel`), handle new files, and verify with `patch -p1 --dry-run` then `composer install`.

Includes a report template, common-gotchas section, and example interactions, following the format of the existing skills.

## README currency (requested)

- Rebuilt the Architecture **Agent Skills** roster to list all **53** current skills, grouped by capability. It was missing ~12 (worktree-manager, drupal-sdc-twig, drupalorg-contribution-helper, drupalorg-issue-helper, gtm-performance-audit, strategic-thinking, teamwork-task-creator/integrator/exporter, wp-devops-setup, wp-plugin-to-private-package, and this new skill).
- Added curated **Key Features** sections that were entirely absent: Development Workflow, Drupal.org Contribution, DevOps & Onboarding; and surfaced `gtm-performance-audit`, `structured-data-analyzer`, `drupal-sdc-twig`, and `strategic-thinking`.

## Registration

- `skills/README.md` — added as entry #53.
- `docs/agents-and-skills.md` — added to the Skills Reference Table.
- `CHANGELOG.md` — `[Unreleased]` Added/Changed entries.

## Testing

- `bats tests/test-plugin.bats` — all 98 pass, including "skill directory count matches documented skills in README" (53 = 53, no duplicate numbering) and the frontmatter checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N344br6eSQxXZFQwfCcjnt
