### PR TITLE
feat(commit-message-generator): append the Assisted-by git trailer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `commit-message-generator` now appends the `Assisted-by: <Vendor>/<model-id>`
+  git trailer when AI assisted in producing the change — vendor-neutral
+  (Claude, GPT, Gemini, or any other LLM), one line per assisting model,
+  skipped for purely human-authored changes. This implements the per-commit
+  provenance convention documented alongside the Delivery Record; audit with
+  `git log --grep="^Assisted-by:"`.
+
 ## [2.0.0] - 2026-07-16
 
 ### Changed — BREAKING

--- a/evals/routing-prompts.json
+++ b/evals/routing-prompts.json
@@ -76,6 +76,10 @@
     {
       "prompt": "generate a composer patch for this contrib module fix and wire it into composer.json",
       "expect": "composer-patch-generator"
+    },
+    {
+      "prompt": "commit this with the AI attribution trailer so we have the audit trail",
+      "expect": "commit-message-generator"
     }
   ]
 }

--- a/skills/commit-message-generator/SKILL.md
+++ b/skills/commit-message-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit-message-generator
-description: Automatically generate conventional commit messages when user has staged changes and mentions committing. Analyzes git diff and status to create properly formatted commit messages following conventional commits specification. Invoke when user mentions "commit", "staged", "committing", or asks for help with commit messages.
+description: Automatically generate conventional commit messages when user has staged changes and mentions committing. Analyzes git diff and status to create properly formatted commit messages following conventional commits specification, and appends the Assisted-by git trailer recording which AI model (Claude, GPT, Gemini, or any other LLM) assisted the change. Invoke when user mentions "commit", "staged", "committing", or asks for help with commit messages.
 ---
 
 # Commit Message Generator
@@ -139,15 +139,53 @@ feat(auth): add two-factor authentication support
 - Plugin work: `fix(plugin): correct ACF field validation`
 - Blocks: `feat(blocks): add testimonial Gutenberg block`
 
-### 5. Present to User for Approval
+### 5. Append the Assisted-by Trailer
+
+When AI assisted in producing the **change itself** (not merely this commit
+message), append an `Assisted-by:` git trailer as the last block of the
+message — the per-commit provenance convention adopted by the Linux kernel,
+Fedora, and the OpenInfra Foundation. The per-PR complement is the Delivery
+Record ([kanopi/delivery-record](https://github.com/kanopi/delivery-record)).
+
+**Format** — `Assisted-by: <Vendor>/<model-id>`, using whichever assistant
+actually did the work. This is deliberately vendor-neutral:
+
+```
+Assisted-by: Claude/claude-fable-5
+Assisted-by: OpenAI/gpt-5.4-codex
+Assisted-by: Google/gemini-3-pro
+```
+
+Rules:
+
+- Identify the current session's model from your own runtime context; never
+  guess or hardcode a model name. One trailer line per assisting model if
+  more than one contributed.
+- Place trailers at the end of the message, after any `Refs:` /
+  `BREAKING CHANGE:` footers, so `git interpret-trailers` and
+  `git log --grep="^Assisted-by:"` work.
+- **Skip the trailer** when the change was written entirely by a human and
+  AI only helped phrase this commit message — the trailer attests to the
+  change, not the prose. Also skip on explicit request (`--no-assisted-by`).
+- This trailer replaces `Co-Authored-By` for AI attribution — never add
+  `Co-Authored-By: Claude…` (or any AI co-author line) to commit messages.
+
+The audit trail this enables:
+
+```bash
+git log --grep="^Assisted-by:"        # every AI-assisted commit
+git log --grep="^Assisted-by: Claude" # by vendor
+```
+
+### 6. Present to User for Approval
 
 Show the generated commit message in a clear code block and ask:
 
 > "Here's a commit message based on your staged changes. Would you like me to commit with this message, or would you like to modify it?"
 
-Wait for explicit user approval (e.g., "approve", "yes, commit", or an edited version) before running `git commit`. Never add `Co-Authored-By: Claude…` to commit messages.
+Wait for explicit user approval (e.g., "approve", "yes, commit", or an edited version) before running `git commit`.
 
-### 6. Execute Commit (only after approval)
+### 7. Execute Commit (only after approval)
 
 ```bash
 git commit -m "commit message here"
@@ -161,6 +199,9 @@ feat(auth): add two-factor authentication support
 - Implement TOTP-based 2FA
 - Add backup codes generation
 - Include recovery flow
+
+Refs: PROJ-123
+Assisted-by: Claude/claude-fable-5
 EOF
 )"
 ```
@@ -169,7 +210,7 @@ EOF
 
 This skill is invoked directly by the main session when the user mentions committing — there is no orchestrator agent in between. The skill works the same way whether triggered conversationally ("I'm ready to commit") or explicitly ("generate a commit message").
 
-The companion **`pr-create`** skill picks up where this one ends — once you've committed, ask to "create a PR" and `pr-create` will generate the PR description from your commits.
+The companion **`pr-create`** skill picks up where this one ends — once you've committed, ask to "create a PR" and `pr-create` will generate the PR description from your commits. The `Assisted-by:` trailers this skill writes are the per-commit half of Kanopi's provenance model; the per-PR half is the Delivery Record ([kanopi/delivery-record](https://github.com/kanopi/delivery-record)).
 
 ## Best Practices
 
@@ -192,6 +233,8 @@ fix(auth): resolve session timeout on remember-me login
 
 - Correct cookie expiration logic
 - Add test coverage for remember-me flow
+
+Assisted-by: Claude/claude-fable-5
 
 Would you like me to commit with this message?
 ```


### PR DESCRIPTION
## Description
Teamwork Ticket(s): n/a (plugin feature)
- [x] Was AI used in this pull request?

> As a developer using AI assistance, I need each commit to record which model assisted the change so that `git log` provides a complete per-commit audit trail complementing the per-PR Delivery Record.

The `Assisted-by:` trailer convention was documented on the ai-workflow site and referenced in delivery-record's prose, but `commit-message-generator` never implemented it. This adds the workflow step: append `Assisted-by: <Vendor>/<model-id>` as a proper git trailer when AI assisted in producing the **change** (not merely the message). It is deliberately **vendor-neutral** — `Claude/claude-fable-5`, `OpenAI/gpt-5.4-codex`, `Google/gemini-3-pro` — with one line per assisting model, identified from the session's own runtime context (never guessed).

## Acceptance Criteria
* Trailer placed after `Refs:`/`BREAKING CHANGE:` footers so `git interpret-trailers` and `git log --grep="^Assisted-by:"` work
* Skipped for purely human-authored changes and on `--no-assisted-by`
* Explicitly replaces `Co-Authored-By` for AI attribution (already banned by the skill)
* Skill description, examples, CHANGELOG, and routing evals updated

## Assumptions
* Vendor prefix convention is `<Vendor>/<model-id>` matching the ai-workflow site's example
* This PR's own commit carries the trailer (dogfooded)

## Steps to Validate
1. `./scripts/validate-frontmatter.sh` — clean
2. `node scripts/run-evals.js --min-rank1 75` — 20/20 rank-1 including the new prompt
3. `bats tests/` — 0 failures
4. Read the new "Append the Assisted-by Trailer" section in `skills/commit-message-generator/SKILL.md`
5. `git log --grep="^Assisted-by:"` on this branch shows the dogfooded commit

## Affected URL
n/a

## Deploy Notes
None — skill content only. The ai-workflow site's delivery-record page becomes accurate on merge, no site change needed.