### PR TITLE
feat(ddev-workflow): add a skill for running a Kanopi DDEV site day to day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   format may only appear with real tool output behind it; unavailable
   tooling yields "Standards not verified" plus the exact command, never
   an eyeballed pass.
+- `ddev-workflow`: running a Kanopi DDEV site day to day. Agents reach for
+  `ddev start` and bare `npm run build` and end up with a booted container,
+  no database, and no compiled assets; the add-ons solve this with custom
+  commands that nothing told the agent about. The skill covers the lifecycle
+  (init, database refresh, front-end build, e2e suites), the host-versus-web
+  split, and the aliases people actually say, plus a symptom-to-fix
+  troubleshooting table.
+- `ddev-workflow` teaches discovery before any command list: detect the add-on
+  from `.ddev/commands/{host,web}/`, then read the real command set from
+  `ddev help` or the `## Description` / `## Usage` / `## Aliases` headers the
+  command files already carry. The skill says outright that the project wins
+  over its own tables, because sites customize their commands.
 
 ### Changed
+
+- `docs/kanopi-tools/ddev-commands.md` regenerated from the add-on command
+  headers: 34 commands with aliases, platform, and the host-versus-web split,
+  up from a hand-written 7. Labeled a dated snapshot that points at
+  `ddev help` as the live source. The old list had drifted enough to omit
+  `playwright-*`, `recipe-apply`, and `theme-create-block` entirely.
 
 - `code-standards-checker` is now discovery-first. Instead of a "Quick Start
   (Kanopi Projects)" branch listing memorized command names, it reads the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `ddev-workflow`: read-before-name hard rule plus a CANT red-flag list. The
+  behavioral case below caught the first draft answering entirely from the
+  skill's own tables — zero tool calls — on a fixture whose commands are
+  deliberately not the add-on defaults. The tables are now labeled as defaults
+  that must be confirmed against the project, and the skill must name none if
+  it cannot read the command set.
+- Behavioral eval case `ddev-workflow--reads-commands-not-recalls` (CANT-20)
+  and fixture `ddev-project-custom-commands`: a DDEV project shipping
+  `project-init`, `db-refresh-scrubbed`, and `assets-compile` and no plain
+  `db-refresh`. The case grades that the answer names the project's own
+  commands and never the add-on names this project does not have.
 - `docs/kanopi-tools/ddev-commands.md` regenerated from the add-on command
   headers: 34 commands with aliases, platform, and the host-versus-web split,
   up from a hand-written 7. Labeled a dated snapshot that points at

--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ Figma → WordPress blocks, Drupal paragraphs with browser validation.
 - `drupal-sdc-twig` - Best practices for Drupal Single Directory Components (Twig)
 
 ### Development Workflow
-Parallel work with git worktrees and safe changes to Composer-managed dependencies.
+Running the local site, parallel work with git worktrees, and safe changes to Composer-managed dependencies.
 
 **Skills:**
+- `ddev-workflow` - Run a Kanopi DDEV site day to day (init, database pulls, front-end build, e2e suites)
 - `worktree-manager` - Create, list, and tear down git worktrees (Kanopi branch conventions, DDEV isolation)
 - `composer-patch-generator` - Generate and maintain CI-safe patches for Composer packages (cweagans/composer-patches)
 
@@ -127,7 +128,7 @@ PR workflows (`pr-create`, `pr-review`, `pr-release`, `commit-message-generator`
 ### Agent Skills
 
 Model-invoked skills that activate during conversation, across Claude Code, Claude Desktop, and OpenAI Codex:
-- **PR & development workflow:** commit-message-generator, pr-create, pr-review, pr-release, worktree-manager, composer-patch-generator
+- **PR & development workflow:** commit-message-generator, pr-create, pr-review, pr-release, ddev-workflow, worktree-manager, composer-patch-generator
 - **Testing & code quality:** code-standards-checker, test-scaffolding, test-plan-generator, coverage-analyzer, documentation-generator
 - **Design-to-code:** design-analyzer, design-to-wp-block, design-to-drupal-paragraph, responsive-styling, browser-validator, drupal-sdc-twig
 - **Drupal.org contribution:** drupal-contribute, drupal-issue, drupal-mr, drupal-cleanup, drupalorg-contribution-helper, drupalorg-issue-helper

--- a/docs/agents-and-skills.md
+++ b/docs/agents-and-skills.md
@@ -456,6 +456,7 @@ Don't try to "game" the system—just describe what you need:
 | pr-review | "review this PR", "review my changes" | PR review or pre-PR self-review | `pr-review` |
 | pr-release | "prepare a release", "generate a changelog" | Changelog + deployment checklist | `pr-release` |
 | worktree-manager | "new worktree", "work on two tickets at once" | Parallel tickets/sessions with DDEV isolation | `worktree-manager` |
+| ddev-workflow | "site won't load", "fresh database", `ddev init`, `db-refresh` | Running a Kanopi DDEV site day to day: init, databases, front-end build, e2e suites | `ddev-workflow` |
 | code-standards-checker | "standards", "style" | Code review | `code-standards-checker` |
 | test-scaffolding | "need tests", "how to test" | Single class tests | `test-scaffolding` |
 | test-plan-generator | "test plan", "QA" | Test scenarios | `test-plan-generator` |

--- a/docs/kanopi-tools/ddev-commands.md
+++ b/docs/kanopi-tools/ddev-commands.md
@@ -1,26 +1,66 @@
 # DDEV Commands
 
-Kanopi DDEV add-ons provide custom commands for theme builds, database management, testing, and more.
+Kanopi's DDEV add-ons ship custom commands for project setup, databases,
+theme builds, and testing.
 
-See [Kanopi Tools Overview](overview.md) for complete list of DDEV commands.
+!!! note "This page is a snapshot"
+    Generated 2026-08-14 from the command headers in
+    [ddev-kanopi-drupal](https://github.com/kanopi/ddev-kanopi-drupal) and
+    [ddev-kanopi-wp](https://github.com/kanopi/ddev-kanopi-wp). Individual sites add
+    and override commands, so **`ddev help` in the project is the live source** —
+    trust it over this page. The `ddev-workflow` skill reads the project rather than
+    this list.
 
-## Quick Reference
+Commands in `.ddev/commands/host/` run on your machine; those in
+`.ddev/commands/web/` run inside the web container. `ddev <command>` dispatches to
+the right side on its own.
 
-### Theme Development
-```bash
-ddev theme-build      # Production build
-ddev theme-watch      # Development mode
-ddev theme-install    # Install dependencies
-```
+## Host commands
 
-### Database
-```bash
-ddev db-refresh       # Pull from Pantheon
-ddev db-rebuild       # Rebuild from scratch
-```
+| Command | Aliases | Platform | Description |
+|---|---|---|---|
+| `ddev cypress-install` | `cypress:install`, `cyi`, `install-cypress` | Both | Install the node packages for cypress on the developers local machine |
+| `ddev cypress-run` | `cy`, `cypress`, `cypress-run`, `cyr` | Both | Run Cypress Commands |
+| `ddev cypress-users` | `cypress:users`, `cyu` | Both | Create Cypress users |
+| `ddev db-rebuild` | `db:rebuild`, `rebuild`, `dbreb` | Both | Runs composer install and database refresh. |
+| `ddev drupal-uli` | `drupal:uli`, `uli` | Drupal | Logs you in to Drupal. |
+| `ddev pantheon-terminus` | `pantheon:terminus`, `terminus` | Both | — |
+| `ddev pantheon-testenv` | `pantheon:testenv`, `testenv` | Both | Initialize stack and testing environment in DDEV. |
+| `ddev playwright-install` | `playwright:install`, `pwi` | Both | Install Playwright and browsers for e2e testing |
+| `ddev playwright-run` | `playwright:run`, `pwr` | Both | Run Playwright e2e tests |
+| `ddev playwright-users` | `playwright:users`, `pwu` | Both | **Drupal:** Create Playwright test users in Drupal · **WordPress:** Create Playwright test users in WordPress |
+| `ddev project-auth` | `project:auth` | WordPress | Authorizes you into DDEV. |
+| `ddev project-configure` | `configure`, `project:configure`, `prc` | Both | **Drupal:** Interactive configuration wizard for Kanopi Drupal DDEV · **WordPress:** Interactive configuration wizard for Kanopi WordPress DDEV |
+| `ddev project-init` | `project:init`, `init` | Both | **Drupal:** Initialize local development. · **WordPress:** Initialize local WordPress development environment. |
+| `ddev project-lefthook` | `project:lefthook` | Both | Initialize Lefthook. |
+| `ddev project-nvm` | `project:nvm` | Drupal | Initializes NVM. |
+| `ddev project-wp` | `project:wp` | WordPress | Install & WordPress if needed. |
+| `ddev wp-open` | `open`, `wp:open` | WordPress | Open the site or admin in your default browser using ddev launch |
 
-### Testing
-```bash
-ddev cypress-run      # E2E tests
-ddev critical-run     # Critical CSS tests
-```
+## Web container commands
+
+| Command | Aliases | Platform | Description |
+|---|---|---|---|
+| `ddev critical-install` | `critical:install`, `install-critical-tools`, `cri` | Both | Initialize/reinstall tools needed for critical CSS. |
+| `ddev critical-run` | `critical:run`, `critical`, `crr` | Both | Run Critical CSS Commands |
+| `ddev db-prep-migrate` | `db:prep-migrate`, `migrate-prep-db` | Both | Create and configure the migration database inside the DDEV web container |
+| `ddev db-refresh` | `db:refresh`, `refresh` | Both | **Drupal:** Downloads the database from the hosting provider. Supports both Pantheon and Acquia platforms. · **WordPress:** Downloads the database from the hosting provider. Supports Pantheon, WPEngine, Kinsta, and Remote SSH platforms. |
+| `ddev drupal-open` | `drupal:open`, `open` | Drupal | Open the site or admin in your default browser |
+| `ddev pantheon-tickle` | `pantheon:tickle`, `tickle` | Both | Continuously wake up a Pantheon environment. |
+| `ddev recipe-apply` | `recipe:apply`, `recipe`, `ra` | Drupal | Apply a Drupal Recipe. |
+| `ddev recipe-unpack` | `recipe:unpack`, `ru` | Drupal | Unpack a recipe package that's already required in your project |
+| `ddev recipe-uuid-rm` | `recipe:uuid-rm`, `uuid-rm` | Drupal | Remove UUIDs and _core metadata from Drupal config files. |
+| `ddev theme-activate` | `activate-theme`, `tha`, `theme:activate` | WordPress | — |
+| `ddev theme-build` | `theme:build`, `production`, `thb`, `theme-production` | Both | Build production assets for the theme |
+| `ddev theme-create-block` | `create-block`, `thcb`, `theme:create-block` | WordPress | Create a new WordPress block |
+| `ddev theme-install` | `theme:install`, `install-theme-tools`, `thi` | Both | Install and set up theme development tools in DDEV |
+| `ddev theme-npm` | `theme:npm` | Both | Runs NPM commands on the theme. |
+| `ddev theme-npx` | `theme:npx` | Both | Runs NPX commands on the theme. |
+| `ddev theme-watch` | `theme:watch`, `development`, `thw`, `theme-development` | Both | **Drupal:** Start theme development with file watching · **WordPress:** Run @wordpress/scripts in development mode for the theme |
+| `ddev wp-restore-admin-user` | `restore-admin-user`, `wp:restore-admin-user` | WordPress | — |
+
+## Related
+
+- The `ddev-workflow` skill covers the lifecycle these commands sit in: what to run
+  on a fresh clone, how to get a database, and how theme assets get built.
+- [Kanopi Tools Overview](overview.md)

--- a/evals/cases/ddev-workflow--reads-commands-not-recalls.json
+++ b/evals/cases/ddev-workflow--reads-commands-not-recalls.json
@@ -1,0 +1,27 @@
+{
+  "name": "ddev-workflow--reads-commands-not-recalls",
+  "skill": "ddev-workflow",
+  "fixture": "ddev-project-custom-commands",
+  "prompt": "I just cloned this project and I need a fresh database. What do I run?",
+  "max_turns": 8,
+  "smoke": true,
+  "cant": ["CANT-20"],
+  "expectations": [
+    {
+      "type": "tool_called",
+      "pattern": "(?i)\\.ddev/commands"
+    },
+    {
+      "type": "output_matches",
+      "pattern": "db-refresh-scrubbed|\\bscrub\\b"
+    },
+    {
+      "type": "output_not_matches",
+      "pattern": "ddev db-refresh(?!-scrubbed)"
+    },
+    {
+      "type": "output_not_matches",
+      "pattern": "(?i)ddev (theme-build|theme-npm|theme-install|db-rebuild)"
+    }
+  ]
+}

--- a/evals/fixtures/ddev-project-custom-commands/.ddev/commands/host/project-init
+++ b/evals/fixtures/ddev-project-custom-commands/.ddev/commands/host/project-init
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+## Description: Initialize local development for this project.
+## Usage: project-init
+## Example: "ddev project-init"
+## Aliases: project:init,init
+
+set -euo pipefail
+echo "eval fixture: would install deps and pull a database"

--- a/evals/fixtures/ddev-project-custom-commands/.ddev/commands/web/assets-compile
+++ b/evals/fixtures/ddev-project-custom-commands/.ddev/commands/web/assets-compile
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+## Description: Compile the front-end assets for the custom theme.
+## Usage: assets-compile
+## Example: "ddev assets-compile"
+## Aliases: assets:compile,assets
+
+set -euo pipefail
+echo "eval fixture: would compile assets"

--- a/evals/fixtures/ddev-project-custom-commands/.ddev/commands/web/db-refresh-scrubbed
+++ b/evals/fixtures/ddev-project-custom-commands/.ddev/commands/web/db-refresh-scrubbed
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+## Description: Pull the production database and scrub client PII before import. This project has no unscrubbed refresh by policy.
+## Usage: db-refresh-scrubbed [env]
+## Example: "ddev db-refresh-scrubbed live"
+## Aliases: db:refresh-scrubbed,scrub
+
+set -euo pipefail
+echo "eval fixture: would pull and scrub"

--- a/evals/fixtures/ddev-project-custom-commands/.ddev/config.yaml
+++ b/evals/fixtures/ddev-project-custom-commands/.ddev/config.yaml
@@ -1,0 +1,8 @@
+name: eval-fixture
+type: drupal10
+docroot: web
+php_version: "8.3"
+webserver_type: nginx-fpm
+database:
+  type: mariadb
+  version: "10.11"

--- a/evals/fixtures/ddev-project-custom-commands/README.md
+++ b/evals/fixtures/ddev-project-custom-commands/README.md
@@ -1,0 +1,9 @@
+# Eval fixture: DDEV project with site-specific commands
+
+A Kanopi-style DDEV project whose command set is deliberately NOT the add-on
+default. There is no `db-refresh`, no `theme-build`, and no `theme-npm` here.
+The commands that exist are `project-init`, `db-refresh-scrubbed`, and
+`assets-compile`, each declaring its own aliases in its header.
+
+An agent that recites the add-on's usual command names instead of reading
+`.ddev/commands/` will name commands this project does not have.

--- a/evals/fixtures/ddev-project-custom-commands/setup.sh
+++ b/evals/fixtures/ddev-project-custom-commands/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Fixture: DDEV project whose commands are site-specific, not add-on defaults.
+set -euo pipefail
+rm -f setup.sh
+git init -q -b main
+git config user.email eval@kanopi.com
+git config user.name "Behavioral Eval"
+git add -A
+git commit -qm "chore: seed ddev fixture"

--- a/evals/routing-prompts.json
+++ b/evals/routing-prompts.json
@@ -50,6 +50,18 @@
       "expect": "worktree-manager"
     },
     {
+      "prompt": "the site won't load after I cloned it, I just get errors",
+      "expect": "ddev-workflow"
+    },
+    {
+      "prompt": "how do I get a fresh database from Pantheon on my local?",
+      "expect": "ddev-workflow"
+    },
+    {
+      "prompt": "my theme changes aren't showing up — how do I rebuild the assets?",
+      "expect": "ddev-workflow"
+    },
+    {
       "prompt": "extract the colors, typography, and spacing specs from this Figma link",
       "expect": "design-analyzer"
     },

--- a/skills/README.md
+++ b/skills/README.md
@@ -156,6 +156,12 @@ Agent Skills are the universal invocation format — they work in Claude Code, C
 **Purpose**: Generate and wire up Composer patches for contrib projects
 **Related Command**: `/composer-patch-generator`
 
+### 25. ddev-workflow
+
+**Triggers**: "site won't load", "fresh database", "build the theme", `ddev init`, `db-refresh`
+**Purpose**: Run a Kanopi DDEV site day to day — init, database pulls, theme builds, e2e suites — reading the project's real command set instead of a memorized list
+**Related Command**: `/ddev-workflow`
+
 ## How Skills Work
 
 ### Automatic Activation

--- a/skills/ddev-workflow/SKILL.md
+++ b/skills/ddev-workflow/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: ddev-workflow
+description: >-
+  Operate a Kanopi DDEV site day to day — get a fresh clone or worktree actually
+  serving pages, pull a database from the hosting provider, compile the front-end
+  build, and drive the Cypress or Playwright suites. Reads the project's real command
+  set from `ddev help` and `.ddev/commands/` rather than assuming one. Invoke when a
+  local site serves errors or a blank page, containers are up but nothing works, the
+  database is empty or stale, compiled assets are missing after a clone, or the user
+  mentions `ddev start`, `ddev init`, `db-refresh`, `db-rebuild`, `theme-build`,
+  `theme-npm`, `cypress-run`, or `playwright-run`, or asks which ddev commands a
+  project has.
+---
+
+# DDEV Workflow
+
+Daily work in an already-provisioned Kanopi Drupal or WordPress site. Creating and
+tearing down worktrees is `worktree-manager`; this skill is what you run inside one.
+
+`ddev start` boots containers and nothing else. A fresh clone has no database, no
+vendor directory, and no compiled theme assets, so the site will serve errors or a
+blank page until the project's init command finishes. That gap is the single most
+common cause of "my local is broken."
+
+## 1. Detect
+
+```bash
+test -f .ddev/config.yaml && echo "DDEV project"
+ls .ddev/commands/host .ddev/commands/web    # Kanopi add-on commands live here
+```
+
+Platform, from the command set and the repo:
+
+- **Drupal** — `drupal-uli`, `drupal-open`, `recipe-apply` in `.ddev/commands/`;
+  `web/core/lib/Drupal.php` or `docroot/core/`.
+- **WordPress** — `wp-open`, `theme-activate`, `theme-create-block`;
+  `wp-config.php` or `public/wp-content/`.
+
+The two add-ons overlap by roughly 90 percent. Where they differ, it is the
+platform-prefixed commands and the set of hosts `db-refresh` supports.
+
+## 2. Read the real command set
+
+Sites customize their commands, and the add-ons ship more than any document tracks.
+Read the project, then trust that over any list, **including the tables below**:
+
+```bash
+ddev help                                  # every command available in this project
+ddev help db-refresh                       # usage and flags for one command
+
+# Or read the headers directly — each file declares its own contract
+head -20 .ddev/commands/web/db-refresh
+grep -H '^## \(Description\|Usage\|Example\|Aliases\):' .ddev/commands/*/*
+```
+
+Command files carry `## Description`, `## Usage`, `## Example`, and `## Aliases`.
+The aliases matter: most commands answer to two or three names, and the short one is
+what people say out loud.
+
+## 3. Lifecycle
+
+These are stable across sites even when the command list is not.
+
+### Getting a site running
+
+| Step | Command | Notes |
+|---|---|---|
+| Boot containers | `ddev start` | Containers only. The site is not usable yet |
+| Everything else | `ddev init` (alias for `project-init`) | Composer, npm, Lefthook, NVM, and a database pull. Several minutes; run it in the background and do other work |
+| First-time setup wizard | `ddev configure` (`project-configure`) | Interactive; sets hosting provider, theme path, and the rest |
+
+After `ddev start` on a fresh clone or a new worktree, always run `ddev init`. A bare
+`ddev start` is why the site serves nothing.
+
+### Database
+
+| Command | Does |
+|---|---|
+| `ddev db-refresh [env]` (alias `refresh`) | Pull a database from the hosting provider. Drupal: Pantheon, Acquia. WordPress: Pantheon, WPEngine, Kinsta, remote SSH |
+| `ddev db-rebuild` (alias `rebuild`) | `composer install` plus a refresh. The "put it back how it was" command |
+| `ddev db-prep-migrate` | Create and configure the migration database in the web container |
+
+### Theme assets
+
+Build output is compiled and usually gitignored, so a fresh clone has no CSS until
+you build.
+
+| Command | Does |
+|---|---|
+| `ddev theme-install` | Install the theme's build tooling. Once per clone |
+| `ddev theme-build` (alias `production`) | Production build |
+| `ddev theme-watch` (alias `development`) | Watch mode while developing |
+| `ddev theme-npm <args>` | npm inside the container, in the theme directory |
+| `ddev theme-npx <args>` | npx, same |
+
+**Never `cd` into the theme and run bare `npm`.** The Node version and the install
+live in the container, not on the host. `ddev theme-npm` runs in the right directory
+with the right toolchain; a host-side `npm run build` either fails or silently
+produces assets built against the wrong Node.
+
+### Testing
+
+| Command | Does |
+|---|---|
+| `ddev playwright-run` (`pwr`) | Playwright e2e suite. `playwright-install` first, `playwright-users` to seed logins |
+| `ddev cypress-run` (`cy`, `cyr`) | Cypress suite. Same install/users pattern |
+| `ddev critical-run` (`crr`) | Critical CSS generation |
+
+### Getting into the site
+
+| Platform | Command |
+|---|---|
+| Drupal | `ddev drupal-uli` (alias `uli`) for a one-time login link, `ddev drupal-open` (`open`) to launch |
+| WordPress | `ddev wp-open` (`open`) to launch, `ddev wp-restore-admin-user` when the admin account is missing from a pulled database |
+
+### Aliases worth knowing
+
+`init`, `configure`, `refresh`, `rebuild`, `production`, `development`, `open`,
+`testenv`, `uli`. These are what the add-on documentation and other developers use.
+
+## 4. Host versus web commands
+
+`.ddev/commands/host/` runs on your machine; `.ddev/commands/web/` runs inside the
+container. It matters when a command needs host credentials or a browser:
+`pantheon-terminus`, `cypress-*`, and `playwright-*` are host commands, while
+`db-refresh`, `theme-*`, and `recipe-*` run in the web container.
+
+You do not normally choose. `ddev <command>` dispatches correctly on its own. The
+distinction shows up when a command fails on a missing binary: check which side it
+runs on before installing anything.
+
+## 5. Drupal and WordPress specifics
+
+**Drupal** adds recipe tooling: `ddev recipe-apply` (alias `recipe`, `ra`) to apply a
+recipe, `recipe-unpack` for one already required by the project, and `recipe-uuid-rm`
+to strip UUIDs and `_core` metadata from exported config.
+
+**WordPress** adds `ddev theme-create-block` (alias `create-block`) to scaffold a
+block, and `ddev theme-activate` to switch the active theme.
+
+Both add `ddev pantheon-testenv` (alias `testenv`) to stand up a testing environment,
+and `ddev pantheon-tickle` to keep a sleepy Pantheon environment awake.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Site loads but is blank or all errors | Containers started, nothing installed | `ddev init` |
+| Content is missing or ancient | No database, or a stale one | `ddev db-refresh` |
+| Page renders unstyled | Theme never built | `ddev theme-install` then `ddev theme-build` |
+| `npm` errors about Node version | Ran npm on the host | Use `ddev theme-npm` |
+| Cannot log in after a database pull | Production accounts, not local ones | Drupal: `ddev drupal-uli`. WordPress: `ddev wp-restore-admin-user` |
+| A command in this file does not exist | The project customized its commands | `ddev help`. The project is right, this file is a snapshot |
+
+## Related Skills
+
+- `worktree-manager` creates and tears down the worktrees this skill runs inside.
+- `code-standards-checker` for linting after you change code.
+- The command reference in
+  [DDEV Commands](https://kanopi.github.io/cms-cultivator/kanopi-tools/ddev-commands/)
+  is a snapshot of the add-ons. `ddev help` is the live source.

--- a/skills/ddev-workflow/SKILL.md
+++ b/skills/ddev-workflow/SKILL.md
@@ -22,6 +22,21 @@ vendor directory, and no compiled theme assets, so the site will serve errors or
 blank page until the project's init command finishes. That gap is the single most
 common cause of "my local is broken."
 
+**Read-before-name (hard rule):** do not name a single `ddev` command until you have
+read this project's command set, in step 2. Every table in this file is a description
+of the add-on *defaults*; sites add, rename, and remove commands, so a name that is
+right in general can be wrong here. Answering from these tables without reading
+`.ddev/commands/` is CANT-20 in the
+[Catalog of Agent Neutralization Techniques](https://github.com/kanopi/cant), and it
+is the exact failure this skill exists to prevent. If you cannot read the command set,
+say so and name none.
+
+Red flags — stop if you catch yourself thinking:
+
+- "I know the Kanopi commands, I don't need to look" (CANT-20)
+- "It's a Kanopi site, so it'll have `db-refresh`" (CANT-20)
+- "Close enough, they can run `ddev help` themselves" (CANT-7)
+
 ## 1. Detect
 
 ```bash
@@ -41,15 +56,19 @@ platform-prefixed commands and the set of hosts `db-refresh` supports.
 
 ## 2. Read the real command set
 
-Sites customize their commands, and the add-ons ship more than any document tracks.
-Read the project, then trust that over any list, **including the tables below**:
+Required before you answer. Sites customize their commands, and the add-ons ship more
+than any document tracks.
 
 ```bash
 ddev help                                  # every command available in this project
-ddev help db-refresh                       # usage and flags for one command
+ddev help <command>                        # usage and flags for one command
+```
 
-# Or read the headers directly — each file declares its own contract
-head -20 .ddev/commands/web/db-refresh
+If `ddev` cannot be run here — not installed, not started, command denied — read the
+command files instead. They are plain text and each declares its own contract:
+
+```bash
+ls .ddev/commands/host .ddev/commands/web
 grep -H '^## \(Description\|Usage\|Example\|Aliases\):' .ddev/commands/*/*
 ```
 
@@ -57,9 +76,17 @@ Command files carry `## Description`, `## Usage`, `## Example`, and `## Aliases`
 The aliases matter: most commands answer to two or three names, and the short one is
 what people say out loud.
 
+Then answer using **the names this project actually defines**, quoting the alias from
+the header. If the project has no command for what was asked, say that, rather than
+reaching for the name a different project would use. A project that ships
+`db-refresh-scrubbed` and no plain `db-refresh` is telling you something about its
+policy; recommending the command it deliberately does not have is worse than
+answering "this project has no unscrubbed refresh."
+
 ## 3. Lifecycle
 
-These are stable across sites even when the command list is not.
+The *shape* below is stable across sites; the command **names** are add-on defaults
+and must be confirmed against step 2 before you repeat any of them.
 
 ### Getting a site running
 


### PR DESCRIPTION
## Description

Teamwork Ticket(s): none (internal tooling)

> As an agent working in a Kanopi site, I need to know the project's DDEV commands so that I stop leaving developers with a booted container and no usable site.

Agents reach for `ddev start` and bare `npm run build` and get containers with no database and no compiled assets. The add-ons solve this with 34 custom commands, and nothing told the agent they exist.

The skill teaches discovery before any command list: detect the add-on from `.ddev/commands/{host,web}/`, then read the real set from `ddev help` or the `## Description` / `## Usage` / `## Aliases` headers the command files already carry. It states outright that the project wins over its own tables, because sites customize commands. On top of that sits the durable lifecycle (`ddev init` after a fresh clone, `db-refresh`, `theme-install` then `theme-build`, `theme-npm` instead of host npm, the e2e entry points) and a symptom-to-fix troubleshooting table.

Also regenerates `docs/kanopi-tools/ddev-commands.md` from the add-on headers: 34 commands with aliases, platform, and the host-versus-web split, up from a hand-written 7.

## Acceptance Criteria

* Skill reads the project before recommending any command
* All five registration surfaces updated: CHANGELOG, `skills/README.md` entry 25, routing evals, docs Skills Reference Table, top-level README roster
* Routing discriminators against `worktree-manager` hold
* The commands doc is labeled a dated snapshot and points at `ddev help` as live

## Assumptions

* **Stacked on #62.** Base is `feat/code-standards-checker-discovery-first`, so this PR shows only its own changes. Merge #62 first and GitHub retargets this to main.
* The old commands doc had drifted enough to omit `playwright-*`, `recipe-apply`, and `theme-create-block` entirely. The regenerated one is dated and will drift too, which is why the skill reads `ddev help` instead of trusting it.
* Command counts come from the two add-on repos as they exist on disk today: 28 commands each, 34 distinct across both.
* The first description draft cost `code-standards-checker` a prompt about editing SCSS in a theme, because "theme" is a strong token in both. The vocabulary moved onto the failure symptoms this skill owns. Worth knowing if you edit the description.

## Steps to Validate

1. `node scripts/run-evals.js --min-rank1 75 --collision-threshold 0.75` produces 25/25 rank-1, no collisions
2. Confirm `"I need to work on another ticket without losing my current work"` still routes to `worktree-manager`, and `"I just edited the SCSS in the theme"` still routes to `code-standards-checker`
3. `bats tests/` produces 79/79, including the skills-directory-versus-README parity check that entry 25 satisfies
4. Spot-check three rows of `docs/kanopi-tools/ddev-commands.md` against `grep '^## Aliases:' commands/*/*` in the add-on repos

## Deploy Notes

None. New skill directory plus docs; no version bump in this PR.

**Verification actually run on this branch:** all four gates green. `validate-frontmatter.sh` 0 errors, evals 25/25 rank-1 no collisions, `bats tests/` 79/79, `check-codex-parity.sh` in parity.

- [x] Was AI used in this pull request?
