### PR TITLE
docs: bring the docs site in line with the 2.2.0 skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Documentation site brought in line with the 2.2.0 skills. `ddev-workflow` and
+  `ddev-docker-cleanup` were registered in the Skills Reference Table but missing
+  from the command overview table, the quick start, the installation category
+  list, and the index examples; all four now carry them.
+- `docs/commands/code-quality.md` described `code-standards-checker`'s old shape:
+  a "Quick Start (Kanopi Projects)" block of hardcoded aliases plus a fallback for
+  everyone else. Replaced with the discovery flow the skill actually follows, and
+  the "Standards not verified" contract.
+- `docs/commands/pr-workflow.md` described `pr-review` as producing a
+  "comprehensive review report" with a "detailed test plan". It now documents the
+  two axes, the evidence and confidence filters, the 8-finding cap with severity
+  prefixes, and `No issues found` as a valid complete result.
+- Three places claimed quality skills run `ddev composer code-check`. They now say
+  the commands are read from the project's own scripts, with those names as
+  examples.
+
 ### Added
 
 - `ddev-docker-cleanup`: reclaim DDEV and Docker disk and memory by removing

--- a/docs/commands/code-quality.md
+++ b/docs/commands/code-quality.md
@@ -20,25 +20,33 @@ Check coding standards compliance with PHPCS/ESLint for Drupal and WordPress pro
 /code-standards-checker wordpress # WordPress coding standards
 ```
 
-### What It Checks
+### How It Works
 
-- **PHP**: PHPCS against Drupal or WordPress coding standards
-- **JavaScript**: ESLint with the project's configuration
-- **Auto-detection**: Reads project structure to pick the right standard
+The skill discovers commands rather than assuming them. Script aliases are defined by
+each project, so a memorized list goes stale — and recommending a command a project
+never declared is a confusing failure.
 
-### Quick Start (Kanopi Projects)
+1. **Detect** — read the `scripts` blocks in `composer.json` and `package.json` at the
+   level that owns the changed files (theme, plugin, module, or project root), prefix
+   with `ddev` when `.ddev/` exists, and check for config files (`.phpcs.xml.dist`,
+   `phpstan.neon`, `rector.php`, `.eslintrc*`, `.stylelintrc*`) that reveal a
+   configured tool with no alias wrapping it
+2. **Map** — match the changed file type to a job: PHP to PHPCS, Twig to twig-cs-fixer,
+   JS and SCSS to the wp-scripts or ESLint/stylelint commands, with a raw
+   `vendor/bin/…` or `npx …` fallback when no alias exists
+3. **Run auto-fix, then verify** — `phpcbf` before `phpcs`, `format` before `lint:js`,
+   then re-run the check and report what survived
+4. **Report** — remaining violations with `file:line` and the command to re-verify
 
-```bash
-# Drupal
-ddev composer code-check      # phpstan + rector + phpcs in one pass
-ddev composer code-fix        # Auto-fix violations
+Kanopi starter script names (`code-fix`, `code-sniff`, `twig-lint`, `rector-check`) appear
+in the skill as one row of a general alias lookup, alongside vanilla Drupal, WordPress,
+and wp-scripts conventions — a reference to confirm against the project, not a command
+list to recite.
 
-# WordPress
-ddev composer phpcs           # Check standards
-ddev composer phpcbf          # Auto-fix violations
-```
-
-For projects without Kanopi tooling, the skill runs PHPCS/ESLint directly and reports violations with suggested fixes.
+If no alias, binary, or config file exists, the skill says so and offers to install the
+standards rather than guessing. It never certifies compliance from reading code: with
+the tooling unavailable, the summary begins "Standards not verified" and names what
+could not run.
 
 ## composer-patch-generator Skill
 

--- a/docs/commands/overview.md
+++ b/docs/commands/overview.md
@@ -25,6 +25,8 @@ Streamline pull request creation, review, and deployment. PR skills run directly
 | `pr-review` | Review a PR (`/pr-review 123`) or self-review your branch (`/pr-review self`) with focus areas: code, security, breaking, testing, size, performance |
 | `pr-release` | Generate changelog (Keep a Changelog format), deployment checklist, and PR description update |
 | `worktree-manager` | Create, list, and tear down git worktrees with Kanopi branch naming and automatic DDEV isolation so multiple tickets (and AI sessions) run in parallel from one clone |
+| `ddev-workflow` | Run a Kanopi DDEV site day to day: `ddev init` on a fresh clone, database refreshes, the front-end build, and the e2e suites — reading the project's real command set from `ddev help` rather than assuming one |
+| `ddev-docker-cleanup` | Reclaim DDEV/Docker disk and memory by removing orphaned volumes, build cache, and dangling images, protecting every current project's database (report → dry run → confirm → apply) |
 
 ---
 
@@ -137,7 +139,7 @@ Extend CMS Cultivator with WordPress-specific tooling from other sources.
 
 Skills automatically integrate with [Kanopi's DDEV add-ons](../kanopi-tools/overview.md):
 
-- **Quality skills** use `ddev composer code-check`, `phpstan`, `rector-check`
+- **Quality skills** read the project's own `composer.json` / `package.json` scripts (commonly `code-check`, `phpstan`, `rector-check`) rather than assuming a fixed alias
 - **Design skills** suggest `ddev theme-build` and `ddev theme-watch`
 - **Testing skills** leverage `ddev cypress-run` for E2E tests
 - **Worktree management** derives DDEV project names per worktree for isolation

--- a/docs/commands/pr-workflow.md
+++ b/docs/commands/pr-workflow.md
@@ -92,21 +92,27 @@ Review a pull request or analyze your own changes before creating a PR.
 - `size` - Size and complexity assessment
 - `performance` - Performance optimization opportunities
 
-**What it analyzes:**
-- Code quality and maintainability
-- Security vulnerabilities (SQL injection, XSS, CSRF)
-- Breaking changes and migration paths
-- PR size and complexity
-- Test coverage
-- Drupal/WordPress best practices
-- Deployment considerations
+**What it reviews**, on two axes:
+- **Spec** — does the diff do what the linked Teamwork ticket and PR body say it does?
+  Missing, partial, incorrect, or out-of-scope requirements, each quoting the
+  requirement line
+- **Correctness** — bugs in the code the diff touched, including blast radius (a
+  selector, hook, or override that also reaches things the ticket never mentioned) and
+  silent failure (a poll, retry, or fallback that swallows its own failure path)
+
+**What it filters out.** Every candidate must carry a concrete failure scenario, and any
+claim about contrib, plugin, or vendor behavior must cite the `file:line` actually read.
+Candidates are then scored 0–100 and only 80-and-above is reported. A fourteen-item CMS
+exclusion list drops what CI already catches, pre-existing issues, unmodified lines, and
+the other usual false positives.
 
 **Outputs:**
-- Comprehensive review report
-- Size and complexity analysis
-- Breaking changes with severity ratings
-- Detailed test plan
-- Actionable recommendations
+- At most 8 findings, most severe first, each with a severity prefix (Critical,
+  Required, Optional, Nit, FYI), a `file:line`, the failure scenario, and the fix
+- Only the sections that have content — there is no fixed template
+- `No issues found`, plus one line on what was checked, when nothing clears the bar.
+  A clean review is a real result, not a failure to look hard enough
+- A reasoned approve / request changes / comment recommendation
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,8 @@ Natural language (skills auto-activate):
 "Create a block from this design"    → builds a WordPress block pattern
 "I need tests for this class"        → generates test scaffolding
 "Does this follow Drupal standards?" → checks code standards
+"My local site won't load"           → gets DDEV running and the database in
+"Docker is eating my disk"           → reclaims space without losing databases
 ```
 
 Explicit invocation:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -405,6 +405,7 @@ Or just say: "Does this follow Drupal coding standards?" — skills activate aut
 In Claude Code, type `/` to see all available skills. In Codex, type `@` to see installed plugin skills. CMS Cultivator skills are organized by category:
 
 - **PR Workflow**: `/pr-create`, `/pr-review`, `/commit-message-generator`, `/pr-release`, `/worktree-manager`
+- **Local Environment**: `/ddev-workflow`, `/ddev-docker-cleanup`
 - **Design Workflow**: `/design-to-wp-block`, `/design-to-drupal-paragraph`, `/browser-validator`
 - **Testing**: auto-invoked (say "I need tests for this class")
 - **Code Quality**: `/code-standards-checker`, `/composer-patch-generator`
@@ -594,7 +595,7 @@ git status
 
 If you're working on Kanopi projects with DDEV add-ons, see the [Kanopi Tools guide](kanopi-tools/overview.md) for additional integration features:
 
-- **Composer Scripts**: `ddev composer code-check`, `phpstan`, `rector-check`
+- **Composer Scripts**: discovered from the project's `composer.json` (commonly `code-check`, `phpstan`, `rector-check`)
 - **DDEV Commands**: `ddev theme-build`, `ddev cypress-run`, `ddev critical-run`
 - **Database Tools**: `ddev db-refresh`, `ddev db-backup`
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -189,7 +189,7 @@ git commit -m "[selected message]"
 ```bash
 # 1. Run Kanopi quality checks
 # (skills automatically use ddev composer scripts)
-/code-standards-checker   # Uses ddev composer code-sniff
+/code-standards-checker   # Runs the project's own lint scripts
 /coverage-analyzer        # Uses ddev cypress-run
 
 # 2. Patch a contrib dependency safely
@@ -208,6 +208,8 @@ git commit -m "[selected message]"
 /commit-message-generator           # Generate commit message
 /pr-release [focus]                 # Generate changelog and deployment docs
 /worktree-manager [create|list|remove] # Parallel tickets via git worktrees
+/ddev-workflow                      # Get the local site running, database, theme build
+/ddev-docker-cleanup                # Reclaim DDEV/Docker disk safely
 ```
 
 ### 🎨 Design Workflow


### PR DESCRIPTION
## Description

Teamwork Ticket(s): none (internal tooling)

An audit of `docs/` against today's five merges found two kinds of drift.

**Missing.** `ddev-workflow` and `ddev-docker-cleanup` were registered in the Skills Reference Table but absent everywhere else. A diff of the command overview table against `skills/` returned exactly those two and nothing else, so coverage is now complete.

| Doc | Added |
|---|---|
| `docs/commands/overview.md` | Both skills in the command table |
| `docs/quick-start.md` | Both in the development workflow list |
| `docs/installation.md` | New "Local Environment" category |
| `docs/index.md` | Two natural-language trigger examples |

**Stale.** Two pages documented skills as they behaved this morning:

- `docs/commands/code-quality.md` carried a "Quick Start (Kanopi Projects)" block of hardcoded aliases plus a fallback for everyone else — the exact branch structure the `code-standards-checker` rework deleted. Replaced with the detect → map → auto-fix-then-verify → report flow, and the "Standards not verified" contract.
- `docs/commands/pr-workflow.md` advertised a "comprehensive review report" with a "detailed test plan". Neither exists now. It documents the two axes, the evidence and confidence filters, the 8-finding cap with severity prefixes, and `No issues found` as a valid complete result.
- Three places asserted quality skills run `ddev composer code-check`. That was the memorized-alias behavior the rework removed; they now say commands come from the project's own scripts, with those names as examples.

## Assumptions

* `docs/agents-and-skills.md` has only 7 numbered "Available Skills" sections against 26 skills. That's pre-existing and by design — the Skills Reference Table below it is the exhaustive list, and it does include both new skills. Not expanded here.
* pm-skills has no `docs/` directory; its documentation is `README.md` and `skills/README.md`, both updated when the skills landed. `MIGRATION.md` is a historical record of the July split and correctly excludes skills that arrived later, so it's untouched.
* One unrelated staleness spotted but **not** fixed, to keep this scoped: `docs/commands/pr-workflow.md` says `commit-message-generator` produces "3-5 commit message options", while the skill generates one message and presents it for approval. Predates today's work — happy to fix separately.

## Steps to Validate

1. `bats tests/` → 83/83, including the Zensical build test that catches broken links
2. `zensical build --clean` renders without errors
3. Diff the overview table against the directory:
   `comm -23 <(ls -d skills/*/ | xargs -n1 basename | sort) <(grep -oE '^\| \`[a-z0-9-]+\`' docs/commands/overview.md | tr -d '|\` ' | sort -u)` returns nothing
4. Read the rewritten `code-quality.md` section against `skills/code-standards-checker/SKILL.md` and confirm they describe the same workflow

## Deploy Notes

Docs deploy to GitHub Pages automatically on merge to main.

**Verification actually run on this branch:** frontmatter 0 errors, evals 28/28 rank-1 no collisions, bats 83/83, codex parity clean.

- [x] Was AI used in this pull request?