### PR TITLE
docs: correct the commit-message-generator description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Three places claimed quality skills run `ddev composer code-check`. They now say
   the commands are read from the project's own scripts, with those names as
   examples.
+- `commit-message-generator` was documented as producing "3-5 commit message
+  options" with "explanations for each option". It produces one message and
+  presents it for approval. The same page listed `config`, `module`, `theme`,
+  and `plugin` as commit *types*; they are scopes. Both corrected, and the
+  `Assisted-by:` trailer — the headline 2.1.0 feature — is now documented in
+  both places that describe the skill.
 
 ### Added
 

--- a/docs/agents-and-skills.md
+++ b/docs/agents-and-skills.md
@@ -153,9 +153,10 @@ Agent Skills are **model-invoked** capabilities—Claude decides when to use the
 
 **What it does:**
 - Analyzes `git diff --staged`
-- Generates conventional commit message
-- Follows project's commit style
+- Generates one conventional commit message and presents it for approval
+- Follows the repository's existing commit style
 - Includes proper scope and description
+- Appends an `Assisted-by:` trailer when AI assisted the change itself
 
 **Example:**
 ```

--- a/docs/commands/pr-workflow.md
+++ b/docs/commands/pr-workflow.md
@@ -125,19 +125,23 @@ Generate conventional commit messages from staged changes.
 # Stage your changes first
 git add .
 
-# Generate commit message options
+# Generate the commit message
 /commit-message-generator
 ```
 
 **What it generates:**
-- 3-5 commit message options
-- Follows conventional commits format
-- Platform-specific types (Drupal/WordPress)
-- Explanations for each option
+- One commit message, presented for approval before anything is committed
+- Conventional commits format, matched to the repository's existing commit style
+- An `Assisted-by: <Vendor>/<model-id>` git trailer when AI assisted the change
+  itself, skipped for human-authored changes and never `Co-Authored-By`
+- A suggestion to split the commit when the staged changes cover unrelated work
 
 **Commit types:**
-- `feat`, `fix`, `docs`, `refactor`, `perf`, `test`
-- `config` (Drupal), `module` (Drupal), `theme`, `plugin` (WordPress)
+`feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`, `ci`
+
+**Scopes** are the module, component, or feature area — Drupal work commonly uses
+`config`, `custom_module`, or `hooks`; WordPress work uses `theme`, `plugin`, or
+`blocks`. For example `feat(blocks): add testimonial Gutenberg block`.
 
 ---
 


### PR DESCRIPTION
## Description

Teamwork Ticket(s): none (internal tooling)

Follow-up to #66, which is this PR's base — both touch `docs/commands/pr-workflow.md`, so this is stacked rather than racing it. Merge #66 first and GitHub retargets this to main.

Two false claims on one page, plus a feature documented nowhere.

- **"3-5 commit message options"** with "explanations for each option". The skill generates **one** message and presents it for approval. The multi-option behavior never existed.
- **`config`, `module`, `theme`, `plugin` listed as commit types.** They're scopes. The types are `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`, `ci`. The page now lists the real types and explains scopes separately with a worked example.
- **The `Assisted-by:` trailer was documented nowhere**, despite being the headline feature of 2.1.0. Both places that describe the skill now cover it, including that it replaces `Co-Authored-By` for AI attribution and is skipped for human-authored changes.

## Accuracy sweep

Since the brief was "docs should be accurate to what the skills are", I checked the rest rather than only the reported item:

* Every backticked token in all **26** command-overview rows resolves to something in that skill's own SKILL.md — 0 mismatches, and the row count now matches the directory count exactly
* `browser-validator` (320/768/1024px) and `responsive-styling` (768/1024px) breakpoint claims match their skills
* The five remaining prose sections in `agents-and-skills.md` (`test-scaffolding`, `documentation-generator`, `test-plan-generator`, `coverage-analyzer`, `drupal-sdc-twig`) check out against their skills

No other drift found.

## Steps to Validate

1. Read `docs/commands/pr-workflow.md` against `skills/commit-message-generator/SKILL.md` — types list should match the skill's `**Types**:` block exactly
2. `bats tests/` → 83/83, including the Zensical build
3. Re-run the token check: for each `| \`skill\` | … |` row in `docs/commands/overview.md`, every backticked token appears in that skill's SKILL.md

## Deploy Notes

Docs deploy to GitHub Pages on merge to main.

**Verification actually run on this branch:** frontmatter 0 errors, evals 28/28 rank-1 no collisions, bats 83/83.

- [x] Was AI used in this pull request?