### PR TITLE
docs(ddev-docker-cleanup): explain the bash 3.2 accommodations in lib.sh

### DIFF
--- a/skills/ddev-docker-cleanup/scripts/lib.sh
+++ b/skills/ddev-docker-cleanup/scripts/lib.sh
@@ -17,8 +17,18 @@ require_deps() {
   fi
 }
 
-# bash 3.2 (macOS system bash) has no `mapfile`. Provide a minimal shim that
-# covers the only usage here: `mapfile -t VAR < <(...)`.
+# These scripts target bash 3.2, the system bash on macOS (/bin/bash, 3.2.57),
+# not just bash 4+ from Homebrew. Two accommodations follow, both backward
+# compatible so the scripts still run unmodified on bash 5:
+#
+#   1. The `mapfile` shim below. bash 3.2 has no `mapfile` builtin.
+#   2. `${ARR[@]+"${ARR[@]}"}` wherever an array is expanded. Under `set -u`,
+#      bash 3.2 treats "${ARR[@]}" on an *empty* array as an unbound variable
+#      and aborts. The `+` form expands to nothing instead. Do not "simplify"
+#      those to "${ARR[@]}" — it breaks only on macOS system bash, and only
+#      when the array is empty, which is the no-projects-found path.
+#
+# The shim covers the only usage here: `mapfile -t VAR < <(...)`.
 if ! type mapfile >/dev/null 2>&1; then
   mapfile() {
     local __var="" __line


### PR DESCRIPTION
## Description

Teamwork Ticket(s): none (internal tooling)

Salvage before deletion. `ddev-docker-cleanup` came from a standalone `~/Projects` directory whose `README.md` was **not** copied into the plugin — only `SKILL.md` and `scripts/` were. That directory is now being deleted, so anything the README uniquely held would go with it.

I diffed the README against the shipped skill. Everything was already covered — the safety model, the `jq` requirement, volume naming, OrbStack reclaim behavior, backup commands — except one thing:

**Why these scripts avoid bash 4 features.** macOS system bash is 3.2.57 at `/bin/bash`, and the upstream version used `mapfile`, which doesn't exist there.

The `mapfile` shim already had an inline comment. The second accommodation did not: `${ARR[@]+"${ARR[@]}"}` appears **four times** across the three scripts with nothing explaining it. Under `set -u`, bash 3.2 treats `"${ARR[@]}"` on an empty array as an unbound variable and aborts — so the plain form fails precisely on the no-projects-found path, on macOS only, which is also the path the safety model depends on refusing.

It reads like noise, and it's the first thing a future cleanup would delete.

## Assumptions

* Comment only, no behavior change. `bash -n` clean and `report.sh` verified still running.
* The scripts in the plugin are byte-identical to the source directory's, so nothing else is lost in the deletion.

## Steps to Validate

1. `bash -n skills/ddev-docker-cleanup/scripts/lib.sh` exits 0
2. `bash skills/ddev-docker-cleanup/scripts/report.sh` still prints the protected project list
3. `bats tests/` → 83/83

## Deploy Notes

None. Comment-only; no version bump needed.

- [x] Was AI used in this pull request?