### PR TITLE
feat(pr-review): rebuild around a specialist agent, verify votes, and non-blocking posting

### DIFF
--- a/.codex/agents/pr-review-specialist.toml
+++ b/.codex/agents/pr-review-specialist.toml
@@ -1,0 +1,40 @@
+name = "pr-review-specialist"
+description = "Review a diff in a fresh context using the pr-review skill's output contract. Spawned by the pr-review skill for self-reviews so the reviewer holds none of the reasoning that produced the code. Read-only. Never posts, never edits files, never spawns another agent. Invoke through the pr-review skill rather than directly."
+model = "inherit"
+
+developer_instructions = """
+## When to Use This Agent
+
+Examples:
+<example>
+Context: User wants their local changes reviewed before opening a PR.
+user: "Review my changes before I open the PR"
+assistant: "I'll use the Task tool to launch the pr-review-specialist agent so the review runs in a fresh context with none of the reasoning that produced the code."
+<commentary>
+The author's context hides the bug. Self-review needs a reader who has not seen the code being written.
+</commentary>
+</example>
+
+# PR Review Specialist Agent
+
+You review a diff in a fresh context. The pr-review skill defines your output contract: one verdict line, findings most severe first, one closing `Unverified:` line, and the filters. Follow it exactly.
+
+## Core Responsibilities
+
+1. **Read the diff** - The base and head named in your prompt, plus uncommitted changes when in scope
+2. **Check the spec axis** - The Teamwork ticket, then the PR body; skip with one line when neither carries requirements
+3. **Check the correctness axis** - The three lenses from the skill: blast radius, silent failure, removed behavior
+4. **Verify each finding** - CONFIRMED, PLAUSIBLE, or REFUTED, per the skill; report only the first two
+5. **Return the review** - The bare three-part shape, nothing else
+
+## Rules
+
+1. Read-only. Never mutate the working tree, index, HEAD, or branch state. Use `git diff`, `git log`, and `git show` to inspect; check nothing out.
+2. Bash is for read-only git and gh commands, `grep`, and syntax checks such as `php -l`. Run nothing that writes.
+3. Never spawn another agent.
+4. No dialogue and no preamble. Output only the review.
+5. Nothing is posted from here. The caller decides delivery. Output the bare review unless your prompt says "delegated", in which case follow the skill's delegated mode.
+"""
+
+[[skills.config]]
+path = "pr-review"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `pr-review` rebuilt from scratch after three same-day reworks each fixed the stated
+  complaint and introduced a new one. The root cause was that every directive in the
+  209-line skill was satisfied by writing more, and each word-limiting instrument tried
+  (hard cap, soft target, per-label budget) either got ignored or bought its words back
+  as jargon. The rebuilt skill has no word or count limits anywhere. Length is bounded
+  by structure instead: a review is exactly one verdict line, findings most severe
+  first, and one closing `Unverified:` line, and a sentence with no slot is deleted.
+- Each finding uses a labeled micro-template: a bold severity headline (`Critical` /
+  `Important` / `Minor`), then `File: path:line`, `Issue:` (the input or state, then the
+  wrong result), and `Fix:` (a `suggestion` block or one named action), one line each.
+  Two locations, because they are often different lines: `File:` is where the problem
+  shows, `Apply:` is where the change goes, omitted when they match. Inline comments
+  anchor at `Apply:`, since that is the line GitHub applies a suggestion to; measured
+  runs put a third of suggestion blocks on the wrong line before this.
+- The 0-100 confidence score with its 80 floor is replaced by verify votes. Each
+  finding is re-read against the file and voted CONFIRMED (quote the triggering line),
+  PLAUSIBLE (state what would confirm it), or REFUTED (quote the line that disproves
+  it, then drop it). A quoted line is checkable; a self-reported number is not. This
+  keeps the verify-before-post step that caught a fabricated claim (`use` after
+  `return` asserted as a syntax error where `php -l` accepts it) on its way to a
+  colleague's PR.
+- Correctness review gains a third lens, removed behavior: for every line the diff
+  deletes or replaces, name the invariant it enforced and find where the new code
+  re-establishes it. All three lenses (blast radius, silent failure, removed behavior)
+  now direct investigation only; their answers reach the output solely as verified
+  findings or on the `Unverified:` line, which also carries shared selectors, hooks,
+  and config keys the review could not clear. The prior wording rewarded narrating
+  lens answers into the review body, which is where a measured 472-word single-finding
+  review came from.
+- Posted reviews carry a body wrapper (see `references/posted-format.md`): an AI Code
+  Review title, Recommendation checkboxes, a Changes Requested section for Critical
+  and Important findings, and a Suggestions section for Minor ones. The checked box
+  and the delegated-mode `FINAL_RECOMMENDATION` sentinel derive from the one
+  recommendation, while the GitHub review event is always a non-blocking comment:
+  reviews post as whoever ran the skill, often an automated routine, and an approve or
+  request-changes event from that account would gate the PR on that person
+  re-reviewing. Self-reviews stay bare and are never posted.
+- Still no Strengths section and no praise, against the obra/superpowers reference
+  this rework otherwise borrows from. Credibility comes from findings that survive
+  verification, not from balancing them with compliments.
+
+### Added
+
+- `pr-review-specialist` agent: `pr-review self` now spawns it so the review runs in a
+  fresh context that holds none of the reasoning that produced the code. Read-only,
+  never spawns another agent, never posts, and inherits the session model: a sonnet pin
+  was measured first and found 0 of 6 known defects across three fixture PRs where the
+  session model found them plus new ones, so the cost saving was rejected. The skill
+  checks the base ref resolves and the diff is non-empty before spawning, and falls
+  back to an in-session review where agents do not exist (Claude Desktop, Codex,
+  sandboxed evals).
+- `skills/pr-review/references/posted-format.md`: the posted-body wrapper spec, loaded
+  only at the posting step.
+- Behavioral eval case `pr-review--findings-are-actionable`, with its
+  `wp-plugin-buggy-change` fixture, graded against the new format: a severity headline,
+  the `Issue:` and `Fix:` labels, a code block, the planted off-by-one still caught, no
+  praise, no internal tooling noise, and a bloat ceiling.
+
 ## [2.3.0] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -121,10 +121,13 @@ Skills spawn specialized agents for focused work:
 **Browser Validation:**
 - browser-validator-specialist
 
+**Code Review:**
+- pr-review-specialist
+
 **Drupal.org Contribution:**
 - drupalorg-issue-specialist, drupalorg-mr-specialist
 
-PR workflows (`pr-create`, `pr-review`, `pr-release`, `commit-message-generator`) run directly from the main session without an orchestrator agent — each skill contains its complete workflow.
+PR workflows (`pr-create`, `pr-review`, `pr-release`, `commit-message-generator`) run directly from the main session without an orchestrator agent — each skill contains its complete workflow. The one exception: `pr-review self` spawns pr-review-specialist so the review runs in a fresh context.
 
 ### Agent Skills
 

--- a/agents/pr-review-specialist/AGENT.md
+++ b/agents/pr-review-specialist/AGENT.md
@@ -1,0 +1,40 @@
+---
+name: pr-review-specialist
+description: Review a diff in a fresh context using the pr-review skill's output contract. Spawned by the pr-review skill for self-reviews so the reviewer holds none of the reasoning that produced the code. Read-only. Never posts, never edits files, never spawns another agent. Invoke through the pr-review skill rather than directly.
+tools: Read, Glob, Grep, Bash
+skills: pr-review
+model: inherit
+color: blue
+---
+
+## When to Use This Agent
+
+Examples:
+<example>
+Context: User wants their local changes reviewed before opening a PR.
+user: "Review my changes before I open the PR"
+assistant: "I'll use the Task tool to launch the pr-review-specialist agent so the review runs in a fresh context with none of the reasoning that produced the code."
+<commentary>
+The author's context hides the bug. Self-review needs a reader who has not seen the code being written.
+</commentary>
+</example>
+
+# PR Review Specialist Agent
+
+You review a diff in a fresh context. The pr-review skill defines your output contract: one verdict line, findings most severe first, one closing `Unverified:` line, and the filters. Follow it exactly.
+
+## Core Responsibilities
+
+1. **Read the diff** - The base and head named in your prompt, plus uncommitted changes when in scope
+2. **Check the spec axis** - The Teamwork ticket, then the PR body; skip with one line when neither carries requirements
+3. **Check the correctness axis** - The three lenses from the skill: blast radius, silent failure, removed behavior
+4. **Verify each finding** - CONFIRMED, PLAUSIBLE, or REFUTED, per the skill; report only the first two
+5. **Return the review** - The bare three-part shape, nothing else
+
+## Rules
+
+1. Read-only. Never mutate the working tree, index, HEAD, or branch state. Use `git diff`, `git log`, and `git show` to inspect; check nothing out.
+2. Bash is for read-only git and gh commands, `grep`, and syntax checks such as `php -l`. Run nothing that writes.
+3. Never spawn another agent.
+4. No dialogue and no preamble. Output only the review.
+5. Nothing is posted from here. The caller decides delivery. Output the bare review unless your prompt says "delegated", in which case follow the skill's delegated mode.

--- a/docs/agents-and-skills.md
+++ b/docs/agents-and-skills.md
@@ -20,13 +20,14 @@ Agents are specialized AI assistants that handle complex, multi-step workflows. 
 - **browser-validator-specialist** - Real-browser validation via Chrome DevTools MCP
 - **drupalorg-issue-specialist** - drupal.org issue drafting and formatting
 - **drupalorg-mr-specialist** - Merge request setup on git.drupalcode.org
+- **pr-review-specialist** - Fresh-context code review for `pr-review self`, read-only
 
 **Orchestrators** (coordinate complex workflows):
 
 - **testing-specialist** - Test generation and coverage (inline security and accessibility test scenarios)
 - **design-specialist** - Design-to-code generation (code generation only; skill spawns responsive-styling and browser-validator agents)
 
-PR and development-workflow skills (`pr-create`, `pr-review`, `pr-release`, `commit-message-generator`, `worktree-manager`) run **directly from the main session** without an orchestrator agent — each skill contains its complete workflow.
+PR and development-workflow skills (`pr-create`, `pr-review`, `pr-release`, `commit-message-generator`, `worktree-manager`) run **directly from the main session** without an orchestrator agent — each skill contains its complete workflow. The one exception: `pr-review self` spawns pr-review-specialist so the review runs in a fresh context.
 
 ### How Agents Work
 
@@ -95,8 +96,9 @@ Spawns browser-validator-specialist (validation from test URL)
 | browser-validator-specialist | `design-to-wp-block`, `design-to-drupal-paragraph`, `browser-validator` | Leaf |
 | drupalorg-issue-specialist | `drupal-contribute`, `drupal-issue` | Leaf |
 | drupalorg-mr-specialist | `drupal-contribute`, `drupal-mr` | Leaf |
+| pr-review-specialist | `pr-review` | Leaf; self-review only, read-only |
 
-PR skills (`pr-create`, `pr-review`, `pr-release`, `commit-message-generator`) run directly from the main session — no agent is spawned.
+PR skills (`pr-create`, `pr-review`, `pr-release`, `commit-message-generator`) run directly from the main session — no agent is spawned, except `pr-review self`, which spawns pr-review-specialist.
 
 ### Agent-to-Skill Mapping
 
@@ -109,8 +111,9 @@ Each agent uses specific skills for detailed "how-to" knowledge:
 | design-specialist | design-analyzer, responsive-styling |
 | drupalorg-issue-specialist | drupalorg-issue-helper |
 | drupalorg-mr-specialist | drupalorg-contribution-helper |
+| pr-review-specialist | pr-review |
 
-PR skills (`pr-create`, `pr-review`, `pr-release`, `commit-message-generator`, `worktree-manager`) run directly from the main session — they use the relevant tooling (GitHub CLI, git) without an orchestrator agent.
+PR skills (`pr-create`, `pr-review`, `pr-release`, `commit-message-generator`, `worktree-manager`) run directly from the main session — they use the relevant tooling (GitHub CLI, git) without an orchestrator agent. `pr-review self` is the exception: it spawns pr-review-specialist for a fresh-context review.
 
 ### Why Agents?
 

--- a/docs/commands/pr-workflow.md
+++ b/docs/commands/pr-workflow.md
@@ -84,6 +84,12 @@ Review a pull request or analyze your own changes before creating a PR.
 /pr-review self testing           # Generate test plan
 ```
 
+Self-review spawns the `pr-review-specialist` agent: a fresh context that holds none of
+the reasoning that produced the code, on the session's model, read-only. A developer or an
+agent can run this to check the work before opening the PR. Where agents do not exist
+(Claude Desktop, Codex), the skill says so and reviews in-session; the output is
+identical either way, and nothing is posted in either case.
+
 **Focus options:**
 - `code` - Code quality, readability, maintainability
 - `security` - Security vulnerabilities, input validation
@@ -96,23 +102,43 @@ Review a pull request or analyze your own changes before creating a PR.
 - **Spec** — does the diff do what the linked Teamwork ticket and PR body say it does?
   Missing, partial, incorrect, or out-of-scope requirements, each quoting the
   requirement line
-- **Correctness** — bugs in the code the diff touched, including blast radius (a
-  selector, hook, or override that also reaches things the ticket never mentioned) and
-  silent failure (a poll, retry, or fallback that swallows its own failure path)
+- **Correctness** — bugs in the changed lines and in the unchanged lines of any function
+  the diff touches, investigated through three lenses: blast radius (a selector, hook,
+  or config key that also reaches things the ticket never mentioned), silent failure (a
+  poll, retry, or fallback that swallows its own failure path), and removed behavior (a
+  deleted line whose invariant the new code never re-establishes)
 
 **What it filters out.** Every candidate must carry a concrete failure scenario, and any
-claim about contrib, plugin, or vendor behavior must cite the `file:line` actually read.
-Candidates are then scored 0–100 and only 80-and-above is reported. A fourteen-item CMS
-exclusion list drops what CI already catches, pre-existing issues, unmodified lines, and
-the other usual false positives.
+claim about contrib, plugin, or vendor behavior must quote the `file:line` actually
+read. Each survivor is then re-read against the file and voted CONFIRMED, PLAUSIBLE, or
+REFUTED; only the first two are reported, and a REFUTED vote quotes the line that
+disproves it. Exclusions drop what the linting tools already catch, pre-existing issues
+in code the diff does not touch, and third-party behavior not confirmed by reading the
+source.
 
-**Outputs:**
-- At most 8 findings, most severe first, each with a severity prefix (Critical,
-  Required, Optional, Nit, FYI), a `file:line`, the failure scenario, and the fix
-- Only the sections that have content — there is no fixed template
-- `No issues found`, plus one line on what was checked, when nothing clears the bar.
-  A clean review is a real result, not a failure to look hard enough
-- A reasoned approve / request changes / comment recommendation
+**Outputs:** one review shape in every mode, whether you are reviewing a PR,
+self-reviewing, or running it from an automated routine.
+- A one-line verdict, then the findings most severe first, then a closing `Unverified:`
+  line when something could not be checked, including shared selectors or hooks the
+  review could not clear
+- One labeled micro-template per finding: a bold severity headline (`Critical`,
+  `Important`, `Minor`), then `File: path:line`, `Issue:`, and `Fix:`, one line each
+- Two locations, because they are often different lines: `File:` is where the problem
+  shows, `Apply:` is where the change goes. `Apply:` is omitted when they are the same
+- `Fix:` holds a `suggestion` block with the literal replacement for the `Apply:` line,
+  or one named concrete action. No nameable line to change means no suggestion block,
+  since the block is one click from being merged
+- On posting to a PR, the body carries the AI Code Review title, Recommendation
+  checkboxes, a Changes Requested section (Critical and Important) and a Suggestions
+  section (Minor). Every finding whose `Apply:` line is in the diff becomes an inline
+  comment the author can commit in one click, listed one line each in the body; the
+  rest appear in full in the body. Self-reviews are not posted
+- Reviews post as comment events, never approve or request-changes, because they post
+  as whoever ran the skill (often an automated routine) and a blocking event would
+  gate the PR on that person re-reviewing. The Recommendation checkbox carries the
+  verdict
+- `No issues found`, plus one line on what was checked, when nothing survives. A clean
+  review is a real result
 
 ---
 

--- a/evals/cases/pr-review--findings-are-actionable.json
+++ b/evals/cases/pr-review--findings-are-actionable.json
@@ -1,0 +1,51 @@
+{
+  "name": "pr-review--findings-are-actionable",
+  "skill": "pr-review",
+  "fixture": "wp-plugin-buggy-change",
+  "prompt": "Review my changes on this branch before I open a PR.",
+  "max_turns": 10,
+  "smoke": true,
+  "cant": ["CANT-26"],
+  "expectations": [
+    {
+      "type": "output_matches",
+      "pattern": "(?i)^\\s*\\**(critical|important|minor)\\b"
+    },
+    {
+      "type": "output_matches",
+      "pattern": "(?im)^\\s*[-*]?\\s*\\**(issue|fix)\\**\\s*:"
+    },
+    {
+      "type": "output_matches",
+      "pattern": "(?im)^\\s*[-*]?\\s*\\**file\\**\\s*:.*:\\d+"
+    },
+    {
+      "type": "output_matches",
+      "pattern": "```"
+    },
+    {
+      "type": "output_matches",
+      "pattern": "(?i)(off.by.one|<=|one past|past the end|count\\( ?\\$posts ?\\))"
+    },
+    {
+      "type": "output_not_matches",
+      "pattern": "CANT-\\d|\\$0\\.\\d|behavioral eval|run-behavioral-evals"
+    },
+    {
+      "type": "output_not_matches",
+      "pattern": "(?i)(nice work|great job|well[- ]built|excellent work|solid work|good catch|### strengths)"
+    },
+    {
+      "type": "output_not_matches",
+      "pattern": "(\\S+\\s+){400,}"
+    },
+    {
+      "type": "output_not_matches",
+      "pattern": "(?im)^\\s*[-*]?\\s*\\**(issue|fix)\\**\\s*:.{200,}$"
+    },
+    {
+      "type": "tool_not_called",
+      "pattern": "(?i)gh pr review"
+    }
+  ]
+}

--- a/evals/fixtures/wp-plugin-buggy-change/my-plugin.php
+++ b/evals/fixtures/wp-plugin-buggy-change/my-plugin.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Plugin Name: Eval Fixture Plugin
+ * Description: Fixture for behavioral evals.
+ * Version: 1.0.0
+ */
+
+/**
+ * Return the greeting shown on the front end.
+ *
+ * @return string Escaped greeting text.
+ */
+function eval_fixture_greeting() {
+	return esc_html__( 'Hello from the eval fixture.', 'eval-fixture' );
+}

--- a/evals/fixtures/wp-plugin-buggy-change/setup.sh
+++ b/evals/fixtures/wp-plugin-buggy-change/setup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Fixture: a branch adding a function with an off-by-one loop bound on an added
+# line. Unambiguous, in-diff, and not something a linter reports.
+set -euo pipefail
+rm -f setup.sh
+git init -q -b main
+git config user.email eval@kanopi.com
+git config user.name "Behavioral Eval"
+git add -A
+git commit -qm "feat: initial plugin scaffold"
+
+git checkout -qb feature/recent-post-titles
+cat >> my-plugin.php <<'PHP'
+
+/**
+ * Collect the titles of the most recent posts.
+ *
+ * @param int $limit How many posts to return.
+ * @return string[] Post titles.
+ */
+function eval_fixture_recent_titles( $limit = 5 ) {
+	$posts  = get_posts( array( 'numberposts' => $limit ) );
+	$titles = array();
+
+	for ( $i = 0; $i <= count( $posts ); $i++ ) {
+		$titles[] = $posts[ $i ]->post_title;
+	}
+
+	return $titles;
+}
+PHP
+git add my-plugin.php
+git commit -qm "feat(posts): add eval_fixture_recent_titles()"

--- a/plans/2026-08-16-pr-review-fourth-rework.md
+++ b/plans/2026-08-16-pr-review-fourth-rework.md
@@ -1,0 +1,288 @@
+# pr-review, fourth rework: containment over caps
+
+Date: 2026-08-16 (revised same day after adversarial agent review)
+Repo: `kanopi/cms-cultivator`
+Branch: `feat/pr-review-structure-over-rules` (continues the uncommitted work)
+Prior plan: `plans/2026-08-16-pr-review-third-rework.md`
+Handoff: `plans/2026-08-16-pr-review-handoff.md`
+
+## Goal
+
+Unchanged: reviews short enough that a human reads all of it, specific enough
+that a human or agent makes the fix without a follow-up question. Direct
+language in the reviews and in the skill file itself.
+
+## Decisions made with the user (2026-08-16)
+
+1. **Wrapper scope: posted reviews.** Self output stays bare (verdict,
+   findings, `Unverified:`). Any review destined for posting carries the
+   #315-style wrapper: an "AI Code Review" title, Recommendation checkboxes,
+   a `Changes Requested` section (Critical and Important), a `Suggestions`
+   section (Minor). Delegated reviews are posted by the parent, so delegated
+   output is wrapped too; only self output is bare.
+2. **Recommendation checkboxes: keep**, in the posted body only. The checked
+   box, the GitHub review `event`, and (in delegated mode) the
+   `FINAL_RECOMMENDATION` sentinel all derive from one recommendation; the
+   skill states this so they cannot drift.
+3. **Spawned reviewer: pin to sonnet** (`model: "sonnet"` on the Agent call).
+4. **No word limits at any granularity.** Not per review, not per finding,
+   not per field, not in characters. Every prior word-limiting instrument
+   produced jargon or was ignored. Length is controlled by selectivity (the
+   filters decide how many findings exist) and by containment (slots decide
+   where words may exist), never by compression.
+
+## Length: containment and selectivity, no numbers
+
+Diagnosis, stated with its limits: the #310 review ran 472 words for one
+finding; the template accounts for roughly 85. The review text itself is not
+in the repo, so the split is an estimate, not an artifact. Two candidate
+causes, both addressed:
+
+- The blast-radius lens said each question "owes a named answer"
+  (SKILL.md:86) and the model printed the answers.
+- Acceptance criterion 4 demands #310 surface the containment blast radius,
+  but the evidence filter forbids it as a finding (no constructible failure),
+  so the only way to satisfy the criterion was to leak it as prose.
+
+Mechanisms:
+
+- **Slots are the whole output.** Every sentence lives in a labeled slot:
+  the verdict line, a finding field, or the `Unverified:` line. This rule
+  exists today (SKILL.md:68-69) and was violated; what changes is removing
+  the two directives above that rewarded violating it.
+- **Lenses direct investigation, not output.** Blast radius, silent failure,
+  and the new removed-behavior lens each get two lines: what to investigate,
+  what a candidate looks like. Their answers reach the output only as
+  findings that survive the filters, with one exception below.
+- **The `Unverified:` line is the legal slot for uncleared blast radius.**
+  Shared selectors, classes, hooks, or config carriers the diff touches that
+  the reviewer could not clear are named there in one line. That is what the
+  line means (not confirmed), it satisfies criterion 4 without a fabricated
+  finding, and it removes the leak incentive.
+- **No headline character bound.** Considered (the built-in skill uses 60
+  chars) and rejected by the adversarial review: a character bound is the
+  attempt-2 hard cap re-skinned, and compression lands on the field every
+  reader sees first. The existing instruments stay: bold one-line headline,
+  plain words, no shorthand the author would have to ask about.
+- **No Minor cap.** Considered (cap at 3) and rejected: a cap leaks pressure
+  into severity labels, promoting a fourth Minor to Important or demoting an
+  Important to escape the budget. Minor findings are bounded by the filters
+  like everything else.
+
+## Acceptance criteria (revised)
+
+Criterion 1 is replaced; word thresholds are a mechanism the user has
+rejected twice. The rest carry over from the third-rework plan.
+
+1. **Zero sentences outside a labeled slot** in every fixture review. Word
+   counts per fixture are measured and reported for trend against the
+   251-472 baseline, but not gated.
+2. Every finding carries a `Fix:` that is code or a named concrete action.
+3. Zero unverified claims about language semantics, vendor APIs, or dates.
+4. #310 surfaces the silent poll expiry (as a finding) and the containment
+   blast radius (finding or `Unverified:` line).
+5. A reader who has not seen the diff can state what to change from the
+   review alone. Human judged; this is the readability gate.
+
+## Mined from the references
+
+### Claude Code built-in code-review (extracted from binary 2.1.233)
+
+Adopt:
+
+- **Removed-behavior lens.** For every line the diff deletes or replaces,
+  name the invariant it enforced, then find where the new code re-establishes
+  it. A missing re-establishment is a candidate. No current lens catches a
+  dropped guard.
+- **Anti-padding line**: "if fewer genuine findings exist, report what you
+  have; do not invent to hit a count."
+- **Enclosing-function scope.** Bugs in unchanged lines of a touched function
+  are in scope; the diff re-exposes them. Refines the "lines the PR did not
+  modify" exclusion.
+- **"Quote the line" evidence phrasing** for claims about existing code.
+
+Reject:
+
+- Effort tiers and multi-agent finder fan-out (one-seat rule, cost).
+- Finding floors such as `min(files_changed, 4)` (floors manufacture
+  findings).
+- The 60-character headline bound (see Length section).
+- Its Fix-less one-line finding format (criterion 2 requires a Fix).
+
+### mattpocock/skills (code-review)
+
+Adopt:
+
+- **Fail fast before spawning.** Resolve the base ref and confirm the diff is
+  non-empty before the Agent call.
+
+Reject:
+
+- The 12-smell Fowler baseline (outside correctness scope, ~40 lines).
+- Two parallel subagents per review (cost, one seat).
+- "Under 400 words" budgets (word limits, rejected).
+
+### addyosmani/agent-skills (code-review-and-quality)
+
+Adopt, as single lines:
+
+- Selectivity: one structural problem outranks ten nits.
+- Approval standard: approve when the change improves code health, even if
+  imperfect.
+
+Reject:
+
+- Everything else: checklists, sizing tables, dependency discipline,
+  rationalization tables. Checklist machinery is satisfied by writing more.
+  Its five-prefix severity set conflicts with constraint 2.
+
+### obra/superpowers (re-read)
+
+Adopt:
+
+- **Read-only spawned reviewer**: one line in the Agent prompt forbidding
+  mutation of the working tree, index, HEAD, or branch state.
+
+Reject (re-affirmed): praise mandate, Strengths section, Recommendations
+section.
+
+## SKILL.md rewrite
+
+### Register fixes (handoff problem 1)
+
+Rewrite every line that editorializes:
+
+- `:14` "Ten plausible findings containing two fabrications..." -> "Report
+  only what survives verification. A fabricated finding forces the reader to
+  re-check everything."
+- `:55` "not the reader's problem" -> "State the failure, not the
+  derivation."
+- `:108` "the worst possible reader" -> "The author's context hides the bug.
+  Use a fresh one."
+- `:122` "One review seat... counts for nothing" -> "Never spawn a second
+  reviewer."
+- `:145` "learned to dress itself" -> "No verified list, whatever the
+  heading."
+
+Then a full pass: any sentence that argues, jokes, or persuades becomes an
+instruction or is deleted.
+
+### Line budget (handoff problem 2)
+
+Current file: 166 lines. Additions: removed-behavior lens (+3), anti-padding
+and scope lines (+2), approval and selectivity lines (+2), spawn precheck,
+read-only, and model lines (+3), Unverified blast-radius definition (+2),
+checkbox derivation line (+1). Total roughly +13.
+
+Cuts, sized: example meta-commentary at lines 52-69 (18 -> 6), self-review
+rationale at 105-124 (20 -> 10), filter overlap (12 -> 7), Don't list entries
+not traced to an observed defect (6 -> 3), delegated-mode prose (10 -> 7),
+Related Skills (6 -> 4). Total roughly -35.
+
+The posted-body wrapper spec (about 25 lines with its template) moves to
+`skills/pr-review/references/posted-format.md`, loaded only at the posting
+step. SKILL.md step 6 references it in one line. Projected SKILL.md size:
+166 + 13 - 35 = ~144 without the wrapper in-file. Under 120 requires the
+full editorial pass to find another ~25 lines; if it cannot without losing a
+defect-traced rule, report the landing size honestly rather than cutting a
+rule to hit a number.
+
+### Content changes
+
+1. Worked example: keep the current one, tighten only its register.
+2. Three lenses, two lines each, answers-stay-out wording, blast-radius
+   remainder routed to `Unverified:`.
+3. Filters: anti-padding line, enclosing-function refinement, confidence
+   floor 80 kept as one line. No caps.
+4. Delegated mode: sentinel verbatim (constraint 1). Fix the anchor bug:
+   the parent anchors at `Apply:`, falling back to `File:`; the current text
+   says `File:` (SKILL.md:153-154), which measurement showed produces wrong
+   anchors (handoff, 2 of 6 before `Apply:`). Delegated output is wrapped
+   (decision 1).
+5. Spawn block: `model: "sonnet"`, read-only line, fail-fast precheck.
+6. Step 6 posting: one-line pointer to `references/posted-format.md`.
+
+### Posted-body wrapper (references/posted-format.md)
+
+```markdown
+## AI Code Review
+
+**Recommendation**
+- [ ] Approve
+- [x] Request Changes
+- [ ] Comment
+
+<verdict line>
+
+### Changes Requested
+<Critical and Important findings>
+
+### Suggestions
+<Minor findings>
+
+Unverified: <line, when present>
+```
+
+The checked box matches the review `event` and, in delegated mode, the
+sentinel; all three derive from the one recommendation. Findings anchored to
+a diff line post as inline comments carrying the full template and suggestion
+block; the body lists each as one line (headline plus `File:`) under its
+section so the body scans even when every finding is anchored. Findings with
+no anchor appear in full in the body. Empty sections are omitted. Self output
+never carries the wrapper, so fixture word counts are comparable to baseline.
+
+## Verification
+
+Gates, all must pass:
+
+```bash
+./scripts/validate-frontmatter.sh
+node scripts/run-evals.js --min-rank1 75
+bats tests/
+./scripts/check-codex-parity.sh
+./scripts/run-behavioral-evals.sh --case pr-review--findings-are-actionable
+```
+
+Fixtures, per the handoff's worktree commands, with `Agent` in
+`--allowedTools`:
+
+- kanopi/cms-cultivator#58 (worktree at `pr58-head`)
+- kanopi/cms-cultivator#60 (worktree at `771935b`)
+- kanopi/spokaneairport#310 (worktree at `8624cee`)
+
+**Spawn assertion**: a fixture run counts only if its transcript shows the
+Agent tool call with `model: "sonnet"`. The fallback substitutes silently
+when `Agent` is missing from `--allowedTools` (handoff gotcha), and criterion
+4 must be demonstrated on the model that will actually run, not on the
+parent's stronger model.
+
+Report measured prose word counts per fixture against the 251-472 baseline.
+
+**Posting path**: exercised for real, not left untested. After fixtures pass,
+post one new-format review on kanopi/cms-cultivator#58 through step 6 (user
+confirms before the `gh` call). This validates the wrapper, the inline
+anchors, and the section mapping on the one surface no fixture covers.
+
+## Cleanup and registration
+
+- Update `docs/commands/pr-workflow.md` to match.
+- Update the `[Unreleased]` CHANGELOG entry.
+- Stale reviews on #58 and #60: submitted GitHub reviews cannot be deleted,
+  only dismissed. Dismiss both with a one-line note pointing at the
+  replacement review (user confirms first). The #58 replacement is the
+  posting-path exercise above; #60 gets one only if the user wants it.
+
+## Known limitations carried forward
+
+- The behavioral eval harness rejects `Agent` by design, so the spawn path
+  has no automated test. The manual fixture runs with the spawn assertion
+  above are the coverage. Changing the harness stays out of scope.
+- Whether sonnet finds the #310 poll expiry is demonstrated by one manual
+  run, not a repeatable test. If it misses, the fallback decision (keep
+  sonnet, raise to inherit) returns to the user with the measured output.
+
+## Out of scope
+
+- The behavioral eval harness itself
+- Other skills
+- Converting pr-review into a standing subagent

--- a/plans/2026-08-16-pr-review-from-scratch.md
+++ b/plans/2026-08-16-pr-review-from-scratch.md
@@ -1,0 +1,198 @@
+# pr-review, from scratch: specialist agent, thin skill
+
+Date: 2026-08-16
+Repo: `kanopi/cms-cultivator`
+Branch: `feat/pr-review-structure-over-rules`
+Supersedes: `plans/2026-08-16-pr-review-fourth-rework.md` (kept as history)
+Handoff: `plans/2026-08-16-pr-review-handoff.md`
+
+## Design rule
+
+Build the skill as it would be built today, with no history. Carry from the
+legacy design only what measurement paid for. Every carried item below names
+its evidence; anything without evidence was not carried.
+
+## Architecture
+
+Three files replace the current monolith, following this repo's own pattern:
+agents orchestrate, skills guide.
+
+1. **`agents/pr-review-specialist/AGENT.md`** (new, ~40 lines). A leaf agent
+   that reviews a diff in a fresh context. The properties the current skill
+   enforces through prose become frontmatter declarations:
+   - `model: sonnet` (user decision: pin the spawned reviewer to sonnet)
+   - `tools: Read, Glob, Grep, Bash` with a body rule that all git and gh use
+     is read-only; never mutate the working tree, index, HEAD, or branches
+   - `skills: pr-review` so the agent loads the output contract
+   - Never spawns another agent
+   Constraint 5 (fresh context for self-review) is now implemented by the
+   registry instead of obeyed by a prompt.
+
+2. **`skills/pr-review/SKILL.md`** (rewritten, target ~100 lines). The single
+   source of truth for the output contract, workflow, and filters. The
+   self-review step becomes one line:
+   `Task(cms-cultivator:pr-review-specialist:pr-review-specialist, prompt=...)`
+   plus one fallback line for hosts without agents (Claude Desktop, Codex,
+   sandboxed evals): review in-session, same contract.
+
+3. **`skills/pr-review/references/posted-format.md`** (new, ~30 lines). The
+   posted-body wrapper, loaded only at the posting step.
+
+## Output contract (the skill's core)
+
+The worked example remains the spec, in the current shape:
+
+- One verdict line, findings most severe first, one closing `Unverified:`
+  line. Nothing outside these slots.
+- Per finding: bold one-line headline, `File:`, `Apply:` (when different),
+  `Issue:` (the input or state, then the wrong result), `Fix:` (a
+  ```suggestion``` block or one named action).
+- Severities `Critical` / `Important` / `Minor` (constraint 2).
+- No praise, no Strengths, no verified lists (constraint 3).
+- The `Unverified:` line carries what could not be checked, including shared
+  carriers (selectors, classes, hooks, config keys) the diff touches that the
+  reviewer could not clear. This is the legal slot for uncleared blast
+  radius; it satisfies acceptance criterion 4 without a fabricated finding.
+
+No word limits at any granularity and no finding-count caps (user decision,
+twice; adversarial review showed caps leak pressure into severity labels).
+Length is bounded by selectivity and containment only.
+
+## Mechanism change: verify votes replace the confidence score
+
+The 0-100 self-scored confidence with an 80 floor is dropped. A model grading
+its own certainty is pseudo-precision. Replacement, taken from the built-in
+code-review skill:
+
+After drafting, re-read each finding against the file and assign one of:
+
+- **CONFIRMED**: can name the inputs or state that trigger it and the wrong
+  result. Quote the line.
+- **PLAUSIBLE**: the mechanism is real, the trigger is uncertain (timing,
+  environment, config). State what would confirm it.
+- **REFUTED**: factually wrong or guarded elsewhere. Quote the line that
+  proves it.
+
+Report CONFIRMED findings, and PLAUSIBLE findings with their trigger stated.
+Drop REFUTED. This keeps the verify-before-post step that caught the
+fabricated `use`-statement claim, and makes the filter checkable (a quoted
+line) instead of self-reported (a number).
+
+## Carried from legacy, with evidence
+
+| Item | Evidence |
+|---|---|
+| The 7 handoff constraints, unchanged | decided |
+| `File:` / `Apply:` two locations | wrong anchors 2 of 6 before, 0 of 3 after |
+| Gate list (closed, merged, draft, automated, mechanical) | decided |
+| Exclusions: tooling-caught, unmodified lines, pre-existing, unread third-party | each fired on a real PR |
+| "Never claim a check you ran only in your head" | the `use`-after-`return` fabrication on #58 |
+| Blast-radius and silent-failure lenses | found the #310 poll expiry and #58 table gap |
+| Spec axis: Teamwork link, then PR body, else say so in one line | constraint 4 |
+| Delegated mode contract and sentinel, verbatim | constraint 1; external parser |
+| Silence is a valid result; `No issues found` plus one coverage line | decided in 2.2.0 rework |
+
+Carried user decisions (2026-08-16): wrapper on posted reviews including
+delegated output, Recommendation checkboxes, sonnet pin, no word limits.
+
+Carried from the adversarial review of the fourth-rework plan:
+
+- Lenses direct investigation, never output; the two directives that rewarded
+  leaking ("owes a named answer", criterion-4 pressure) are gone.
+- Delegated anchor bug fixed: the parent anchors at `Apply:`, falling back to
+  `File:` (current text says `File:`, which measurement showed is wrong).
+- Checkbox, review `event`, and sentinel derive from one recommendation.
+- No 60-character headline bound, no Minor cap (re-skinned caps).
+
+New lenses and lines from the reference mining (fourth-rework plan, section
+"Mined from the references", unchanged): removed-behavior lens, anti-padding
+line, enclosing-function scope, fail-fast diff check before spawning,
+approval standard and selectivity as single lines.
+
+## Not carried from legacy
+
+- The 0-100 confidence rubric and 80 floor (replaced by verify votes).
+- The 8-finding cap (a count limit; selectivity and severity ordering bound
+  the list).
+- Every sentence that argues, jokes, or persuades. The register offenders
+  named in the handoff (`:14`, `:55`, `:108`, `:122`, `:145`) and their flat
+  replacements are listed in the superseded plan and apply here.
+- The one-seat rationale paragraphs (now one line: "Never spawn a second
+  reviewer"; the agent frontmatter enforces the rest).
+
+## Posted-body wrapper (`references/posted-format.md`)
+
+```markdown
+## AI Code Review
+
+**Recommendation**
+- [ ] Approve
+- [x] Request Changes
+- [ ] Comment
+
+<verdict line>
+
+### Changes Requested
+<Critical and Important findings>
+
+### Suggestions
+<Minor findings>
+
+Unverified: <line, when present>
+```
+
+Anchored findings post as inline comments carrying the full template and
+suggestion block; the body lists each as one line (headline plus `File:`)
+under its section. Unanchored findings appear in full in the body. Empty
+sections are omitted. Self output never carries the wrapper.
+
+## Work plan
+
+1. Write `agents/pr-review-specialist/AGENT.md`.
+2. Rewrite `skills/pr-review/SKILL.md` against the contract above.
+3. Write `skills/pr-review/references/posted-format.md`.
+4. Register the new agent: Codex TOML in `.codex/agents/`, row in
+   `docs/agents-and-skills.md`, roster entry in the top-level `README.md`.
+5. Update `docs/commands/pr-workflow.md` and the `[Unreleased]` CHANGELOG
+   entry (skill rework and new agent).
+6. Run all gates:
+   `./scripts/validate-frontmatter.sh`, `node scripts/run-evals.js
+   --min-rank1 75`, `bats tests/`, `./scripts/check-codex-parity.sh`,
+   `./scripts/run-behavioral-evals.sh --case pr-review--findings-are-actionable`.
+   The skill description keeps its trigger phrases so routing evals hold.
+7. Fixture runs from the handoff's worktrees (#58, #60, spokaneairport#310
+   at `8624cee`), with `Agent` allowlisted. A run counts only if the
+   transcript shows the specialist agent invoked with sonnet; the fallback
+   substitutes silently otherwise.
+8. Report measured prose word counts per fixture against the 251-472
+   baseline. Reported, not gated.
+9. Posting-path exercise: post one new-format review on cms-cultivator#58
+   through the real step 6 (user confirms before the `gh` call). Dismiss the
+   two stale reviews on #58 and #60 with a one-line note (submitted reviews
+   cannot be deleted; user confirms first).
+
+## Acceptance criteria
+
+1. Zero sentences outside a labeled slot in every fixture review.
+2. Every finding carries a `Fix:` that is code or a named concrete action.
+3. Zero unverified claims about language semantics, vendor APIs, or dates.
+4. #310 surfaces the silent poll expiry (finding) and the containment blast
+   radius (finding or `Unverified:` line).
+5. A reader who has not seen the diff can state what to change from the
+   review alone. Human judged.
+
+## Risks
+
+- The behavioral eval harness rejects `Agent` by design; the spawn path's
+  only coverage is the manual fixture runs with the transcript assertion.
+- Whether sonnet finds the #310 poll expiry is demonstrated by one manual
+  run. If it misses, the decision (keep sonnet or inherit) returns to the
+  user with the measured output.
+- Agent frontmatter cannot scope Bash to read-only commands; the read-only
+  rule stays a body instruction, the one place prose still enforces a
+  property.
+
+## Out of scope
+
+- The behavioral eval harness
+- Other skills

--- a/plans/2026-08-16-pr-review-handoff.md
+++ b/plans/2026-08-16-pr-review-handoff.md
@@ -1,0 +1,153 @@
+# pr-review handoff: current state
+
+Date: 2026-08-16
+Repo: `kanopi/cms-cultivator`
+Branch: `feat/pr-review-structure-over-rules` (branched off `main`)
+
+**The work on this branch is uncommitted.** Read the working tree, not the log. Prior
+attempts are in the log: `47944a6`, `090b218`, `e0a807d` (the last two on
+`feat/pr-review-word-caps`, unmerged). `plans/2026-08-16-pr-review-third-rework.md` is the
+plan this branch implements.
+
+## Goal
+
+Concise, actionable code reviews. Short enough that a human reads all of it, specific
+enough that a human or an agent can make the fix without asking a follow-up question.
+
+No prose, no jargon, no literary flourish. Direct language.
+
+## Uncommitted changes
+
+| File | State |
+|---|---|
+| `skills/pr-review/SKILL.md` | rewritten, 166 lines (was 209) |
+| `docs/commands/pr-workflow.md` | modified to match |
+| `CHANGELOG.md` | `[Unreleased]` entry added |
+| `evals/cases/pr-review--findings-are-actionable.json` | new |
+| `evals/fixtures/wp-plugin-buggy-change/` | new, ported from `feat/pr-review-word-caps` |
+
+## Current output format
+
+Every finding, in every mode:
+
+```
+**Important: `phpunit: TRUE` has nothing left to act on**
+- File: `assets/rector.php:36`
+- Apply: `evals/cases/` (not in this diff)
+- Issue: <one line: the input or state, then the wrong result>
+- Fix: <a ```suggestion block, or one named action>
+```
+
+A review is three parts: a one-line verdict, the findings, and a closing `Unverified:`
+line. `File:` is where the problem shows. `Apply:` is where the change goes, omitted when
+it is the same line. Inline comments anchor at `Apply:` because that is the line GitHub
+applies a suggestion to.
+
+## Constraints that must hold
+
+These are decided. Do not relitigate without asking.
+
+1. Delegated mode, and its `FINAL_RECOMMENDATION: Approve|Request Changes|Comment`
+   sentinel on its own line. An automated routine parses that line verbatim.
+2. Three severities: `Critical` / `Important` / `Minor`.
+3. No Strengths section, no praise, in any form. This includes "what I verified" lists.
+4. Spec axis infers from the Teamwork ticket, then the PR body. When neither exists, say
+   so in one line and skip the axis. Never invent a requirement.
+5. `/pr-review self` hands the diff to a fresh subagent, because whoever asks just wrote
+   the code. Falls back to in-session where `Agent()` does not exist.
+6. Two locations per finding (`File:` / `Apply:`), decided after measuring wrong anchors.
+7. Never claim a check you did not run. Any claim about contrib, plugin, or vendor
+   behaviour cites the `file:line` actually read.
+
+## Measured results
+
+Three fixtures, run headlessly. Prose words exclude code blocks.
+
+| Fixture | Words | Findings | Wrong anchors |
+|---|---|---|---|
+| cms-cultivator#58, in-session | 314 | 3 | 0 |
+| cms-cultivator#58, spawned subagent | 302 | 4 | 0 |
+| cms-cultivator#60 | 251 | 2 | 0 |
+| spokaneairport#310 @ `8624cee` | 472 | 1 | 0 |
+
+Before the current format, the same skill produced 519 and 495 words on #58 and #60 in
+two different shapes. Wrong suggestion anchors ran 2 of 6 before the `Apply:` field and
+0 of 3 after.
+
+`#310` finds the silent poll expiry that commit `235a2bf` later fixed, plus a second one
+the author did not fix. It names the containment blast radius but declines to raise it as
+a finding, having found no constructible failure.
+
+## Known problems
+
+1. **The skill is written in the style it bans.** `SKILL.md:108` "That is the worst
+   possible reader", `:145` "a Strengths section that learned to dress itself", `:122`
+   "One review seat", `:55` "is not the reader's problem". A skill demanding direct
+   language should be written in direct language. This is the largest unfixed problem and
+   it is the reason this handoff exists.
+2. **166 lines against a 120-line target.** The plan's thesis is that rules are the
+   problem and structure is the fix; the file has grown every time a defect appeared.
+3. **Reviews run 250-472 words against a 250-word target.** Four length instruments have
+   been tried: a hard word cap (produced jargon), a soft target (ignored), one line per
+   label (halved it), and "state the failure not the derivation" (helped). None hold it.
+4. **The spawn path has no automated test.** `scripts/run-behavioral-evals.sh` rejects
+   `Agent` via `FORBIDDEN_EXTRA_RE`, by design. All three `pr-review` eval cases drive
+   `self` prompts, so they exercise only the fallback. The default path is untested.
+5. **A spawned review cost $2.08.** Roughly triple in-session. Unbudgeted.
+6. **Two stale reviews are posted** on kanopi/cms-cultivator#58 and #60, from a
+   mid-session version predating `Apply:` and the subagent change.
+
+## Reference implementations
+
+- https://github.com/obra/superpowers/tree/main — `skills/requesting-code-review/code-reviewer.md`.
+  Source of the labelled micro-template and the three severities. Mandates praise; we
+  reject that (constraint 3).
+- https://github.com/addyosmani/agent-skills/tree/main — not yet read.
+- https://github.com/mattpocock/skills/tree/main — not yet read.
+- Claude Code's built-in `code-review` skill — not yet read.
+
+## How to run things
+
+Gates, all four currently pass:
+
+```bash
+./scripts/validate-frontmatter.sh
+node scripts/run-evals.js --min-rank1 75     # routing, 28/28
+bats tests/                                   # 83/83
+./scripts/check-codex-parity.sh
+./scripts/run-behavioral-evals.sh --case pr-review--findings-are-actionable
+```
+
+Fixtures. `#58` and `#60` gate as "already reviewed" if driven by PR number, so they run
+as self-reviews from worktrees pinned at each PR head:
+
+```bash
+git fetch origin pull/58/head:pr58-head
+git worktree add /tmp/cc-pr58 pr58-head
+git worktree add /tmp/cc-pr60 771935b
+git -C ~/Projects/spokane worktree add /tmp/spokane-8624cee 8624cee
+```
+
+Then from inside each worktree:
+
+```bash
+claude -p "/cms-cultivator:pr-review self" --setting-sources "" \
+  --plugin-dir ~/Projects/cms-cultivator --no-session-persistence \
+  --allowedTools "Agent,Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(grep:*),Bash(sed:*),Bash(php:*)"
+```
+
+Gotchas: `--setting-sources ""` blocks every `gh` call unless allowlisted, and the review
+correctly refuses rather than inventing findings. Omitting `Agent` from `--allowedTools`
+silently exercises the fallback path. `timeout` does not exist on macOS.
+
+## Acceptance criteria
+
+From the plan, unchanged:
+
+1. Every review under 250 words of prose, code blocks excluded, no exceptions clause
+2. Every finding carries a `Fix:` that is code or a named concrete action
+3. Zero unverified claims about language semantics, vendor APIs, or release dates
+4. `#310` surfaces the silent poll expiry and the containment blast radius
+5. A reader who has not seen the diff can state what to change from the review alone
+
+Criterion 5 is judged by a human, not by the agent doing the work.

--- a/plans/2026-08-16-pr-review-third-rework.md
+++ b/plans/2026-08-16-pr-review-third-rework.md
@@ -1,0 +1,176 @@
+# pr-review, third rework: structure over rules
+
+Date: 2026-08-16
+Repo: `kanopi/cms-cultivator`
+
+## Problem
+
+`pr-review` was reworked three times on 2026-08-16. Each attempt fixed the stated
+complaint and introduced a new one.
+
+| Attempt | Fixed | Broke | Measured |
+|---|---|---|---|
+| 2.2.0 rework (#64) | Fabricated findings, empty sections | Nothing bounded length | 750 words for 3 findings |
+| Hard word caps | Length | Compression produced jargon: "the builder style", "the chain", "migrators" | 190 words, unreadable |
+| Targets + show-the-code | Jargon, missing fixes | Length returned; target ignored | 640 words against a 250 target |
+
+Reader verdict on attempt 3: "You're right back into prose, comments and jargon again.
+This got much worse."
+
+A fourth round of rule-tuning is not indicated.
+
+## Root cause
+
+The skill is 209 lines carrying 16 separate directives: an evidence rule, a confidence
+rubric, a fourteen-item exclusion list, blast-radius and silent-failure lenses, length
+targets, show-the-code, a plain-language table, no-praise, a closing-line cap, and a
+delegated-mode contract.
+
+**Every one of those directives is satisfied by writing more.** There is no directive
+whose compliance is demonstrated by writing less. Adding a rule to reduce output is
+self-defeating when rules are the output mechanism.
+
+Attempt 2 proved the point from the other side: a hard word cap did reduce length, and
+the model bought those words back by compressing meaning into shorthand. The words went
+down; the comprehension went down further.
+
+## What obra/superpowers does differently
+
+Reference: `skills/requesting-code-review/code-reviewer.md`.
+
+1. **A per-issue micro-template with field labels, not prose.** Each issue is four
+   lines: bold headline, `File:`, `Issue:`, `Fix:`. Labels make padding structurally
+   awkward — there is nowhere to put a subordinate clause. Roughly 20 words per issue.
+2. **A worked example that is the real contract.** Their example output runs about 150
+   words for three issues. Ours has an example too, but it sits beneath 100 lines of
+   prose rules, and the rules win.
+3. **Far fewer directives.** No confidence rubric, no exclusion list, no evidence rule.
+   Discipline comes from a ten-line DO/DON'T list, including "Give feedback on code you
+   didn't actually read" as a single DON'T.
+4. **The caller supplies the spec.** It is a subagent prompt with `[PLAN_OR_REQUIREMENTS]`
+   and `[BASE_SHA]`/`[HEAD_SHA]` placeholders, so the reviewer never guesses at what the
+   change was supposed to do. Our skill infers the spec from a Teamwork link.
+
+Note the direct contradiction with our current skill: **they mandate praise**
+("Acknowledge what was done well before listing issues — accurate praise helps the
+implementer trust the rest of the feedback"). We ban it. Their reasoning is about trust
+calibration, not politeness, and deserves a real answer rather than a reflex.
+
+## Decisions to make
+
+### D1. Replace prose rules with a labeled micro-template
+
+Recommended. Each finding becomes:
+
+```
+**<headline: what is wrong, plain language>**
+- File: `path:line`
+- Issue: <one sentence — what breaks, for whom>
+- Fix: <one sentence, or a fenced code block>
+```
+
+The label is the constraint. `Issue:` followed by three sentences reads visibly wrong
+in a way that a word budget does not.
+
+### D2. The worked example moves to the top and gets treated as the spec
+
+Recommended. A complete example review, at target length, placed before the rules. The
+rules that survive get stated as short DO/DON'T lines beneath it.
+
+### D3. Cut the directive count
+
+Recommended. Candidates to keep, because each traces to a real defect this repo
+observed:
+
+- Evidence rule — killed the two false claims on spokaneairport#310
+- "Never claim a check you did not run" — the `use`-statement fabrication on #58
+- Exclusion 1 (tooling already catches it) and 2/3 (unmodified and pre-existing lines)
+- Eligibility gate
+
+Candidates to cut or compress into single DON'T lines: the 14-item exclusion list down
+to the four that have actually fired, the confidence rubric (keep the 80 floor, drop
+the five-level prose), blast-radius and silent-failure lenses (fold into the DO list as
+two bullets), the plain-language table, the closing-line cap.
+
+Target: under 120 lines, from 209.
+
+### D4. Strengths section — DECIDED: none
+
+No Strengths section, in any form. The reader's complaint is words, and praise is words
+that carry no action. Superpowers' trust-calibration argument is noted and rejected for
+this repo: the reviewer's credibility comes from findings that survive verification, not
+from balancing them with compliments.
+
+### D5. Delivery — DECIDED: inline suggestion blocks
+
+Findings post as inline comments on the changed line, each carrying a
+```suggestion``` block the author commits with one click. This is the structural fix the
+prose rules kept failing to achieve:
+
+- Location prose disappears. The comment is already attached to the line
+- "What to change" cannot be vague, because the block must contain the literal
+  replacement text for those lines
+- The reader's effort drops from "read, navigate, interpret, edit" to "read, click"
+
+Mechanics: `gh api repos/{owner}/{repo}/pulls/{n}/comments` with `path`, `line`, and
+`body`, or a single `gh api ... /reviews` call carrying a `comments` array. The review
+body itself shrinks to a one-line verdict plus anything with no line to attach to
+(missing registration rows, absent eval cases, process gaps).
+
+Constraint to respect: a suggestion block only works on lines present in the diff. A
+finding about a file the PR never touched has no anchor and belongs in the body.
+
+### D6. Spec source — DECIDED: keep inferring, state when absent
+
+Try the Teamwork link, then the PR body. When neither carries requirements, say so in
+one line and skip the axis. Do not invent requirements, and do not require the caller to
+supply them.
+
+Both PRs reviewed on 2026-08-16 had no ticket, so this path is the common one, not the
+exception.
+
+### D7. Severity — DECIDED: three levels
+
+`Critical` / `Important` / `Minor`, matching superpowers. Five levels gave the model
+more to deliberate over and the reader more to decode. Three buckets, and the
+distinction that matters — does this block the merge — is carried by the verdict line,
+not by the prefix.
+
+## Acceptance criteria
+
+Measurable, unlike last time. Re-run against the three fixtures we now have history for:
+kanopi/cms-cultivator#58, #60, and kanopi/spokaneairport#310 at commit `8624cee`.
+
+1. Every review under 250 words of prose, code blocks excluded, with no exceptions
+   clause
+2. Every finding carries a `Fix:` that is code or a named concrete action
+3. Zero unverified claims about language semantics, vendor APIs, or release dates — the
+   `use`-statement class of error
+4. #310 still surfaces the silent poll expiry and the containment blast radius
+5. A reader who has not seen the diff can state what to change from the review alone
+
+Criterion 5 is the one that matters and the one no automated check covers. It needs a
+human read before merge.
+
+## Evidence to preserve
+
+Three defects found today by re-running reviews, all real, none found by CI:
+
+- `#58` — `drupal-rector-update` missing from the 26-row table in
+  `docs/commands/overview.md`; no check covers that table
+- `#58` — CLAUDE.md requires gate and pressure eval cases for side-effect skills;
+  the PR omits them, and `composer-patch-generator` omitted them earlier
+- `#60` — the behavioral eval case cannot run the commands it grades, because
+  `BASE_ALLOWED_TOOLS` lacks `git ls-remote` and `git worktree list`
+
+Also: verifying the review before posting caught a fabricated claim on its way to a
+colleague's PR (`use` after `return` asserted as a syntax error; `php -l` says
+otherwise). **Verify-before-post is part of the workflow, not an optional step**, and
+the skill should say so.
+
+## Out of scope
+
+- The other skills reworked today
+- The behavioral eval harness itself
+- Whether `pr-review` should become a subagent (that is D6, and it is a bigger change
+  than this plan should carry)

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,209 +1,170 @@
 ---
 name: pr-review
 description: >-
-  Review a pull request or analyze local changes before submitting. Checks the diff
-  against what the ticket asked for, then for correctness bugs, and reports only
-  findings that survive a concrete failure scenario and a confidence floor. Silence is
-  a valid result. Auto-activates when the user mentions reviewing a PR, asks for code
-  review, wants to analyze changes before submitting, or mentions "pr-review self".
-  Invoke when the user provides a PR number to review or says "review self", "review
-  my changes", or "pr review". Supports focus areas: code, security, breaking,
-  testing, size, performance.
+  Review a pull request or analyze local changes before submitting. Checks the diff against what
+  the ticket asked for, then for correctness bugs, and reports only findings that survive a
+  concrete failure scenario and verification against the file. Findings post as inline
+  suggestions, and silence is a valid result. Invoke when the user gives a PR number, asks for a
+  code review, wants changes analyzed before submitting, or says "pr review", "review self",
+  "review my changes", or "pr-review self". Focus areas: code, security, breaking, testing, size,
+  performance.
 ---
 
 # PR Review
 
-Review a pull request, or your own changes before you open one. Runs directly in the
-main session; no agents.
+Report only findings that survive verification. A fabricated finding forces the reader to
+re-check everything. Usage: "Review PR #123", "review my changes".
 
-Ten plausible findings containing two fabrications is worse than two verified
-findings, because the reader now has to check everything. Every mechanism below exists
-to delete candidates, not to generate them.
+## Output
 
-Usage: "Review PR #123", "review my changes", optionally with a focus area.
+Copy this shape in every mode. Delivery is decided in step 6 and never changes what you write.
+
+````markdown
+Request changes. The overflow rule clips two card variants the ticket never mentions, and the
+alert dismissal reads an option name nothing writes.
+
+**Critical: the dismissal expiry is read from an option nothing writes**
+- File: `inc/class-alerts.php:88`
+- Issue: The save path writes `alert_dismissed_until`, so this read always falls back to 0 and the alert never stays dismissed.
+- Fix:
+```suggestion
+	$until = (int) get_option( 'alert_dismissed_until', 0 );
+```
+
+**Important: `.card` overflow clips every card variant**
+- File: `css/blocks.css:31`
+- Issue: `.card--profile` and `.card--stat` hang their badge outside the box; this rule cuts it off.
+- Fix:
+```suggestion
+.card--event { overflow: hidden; }
+```
+
+**Minor: `card--event` is missing from the variant table**
+- File: `css/blocks.css:31`
+- Apply: `docs/components/cards.md` (not in this diff)
+- Issue: The table is how the next developer finds a variant, so an absent one gets rebuilt by hand.
+- Fix: Add a `card--event` row beside the existing `card--profile` row.
+
+Unverified: the 781px stacking, since no browser ran here.
+````
+
+Rules for the shape:
+
+- A review is three parts: one verdict line, findings most severe first, one closing
+  `Unverified:` line. Every sentence lives in one of these slots. A sentence with no slot is
+  deleted, not relocated.
+- Each label holds one line. `Issue:` is one short sentence: the input or state, then the wrong
+  result. Write "the last pass reads `$posts[3]` of a 3-item array and fatals on null", not
+  "`count()` is a valid index only up to `count() - 1`, so the loop runs one pass too many and
+  reads an undefined offset, throwing a fatal whenever posts exist". The proof stays in your
+  head; the `Fix:` carries the mechanism.
+- Severity: `Critical` ships a bug, security hole, or data loss. `Important` blocks the merge.
+  `Minor` is the author's call. Approve when the change improves code health, even if imperfect.
+- `File:` is where the problem shows, on every finding. `Apply:` is where the change goes,
+  omitted when that is the same line.
+- `Fix:` is a ```suggestion``` block replacing exactly the `Apply:` line (or the `File:` line
+  when there is no `Apply:`), or one named concrete action. No line to replace, no block.
+- `Unverified:` names what could not be checked, including shared selectors, classes, hooks, or
+  config keys the diff touches that you could not clear.
 
 ## Workflow
 
-### 0. Eligibility gate
+1. **Gate.** Closed, merged, draft, already reviewed with no new commits, automated (dependency
+   bumps, lockfiles, generated files), or purely mechanical (formatting, a uniform rename,
+   comments only): reply `Skipping review:` with the reason and stop.
+2. **Target.** A PR number: review that PR in this session. "self" or "my changes": spawn the
+   specialist (below). A prompt naming a base and head: you are the spawned specialist or an
+   automated routine, so review that diff here, with no dialogue, and never spawn. None of
+   these: ask.
+3. **Context.** In parallel: `gh pr view <n> --json title,body,baseRefName,changedFiles`,
+   `gh pr diff <n>`, `gh pr checks <n>`, and `gh issue view <n>` for any issue the PR or its
+   commits reference. Local diff: against the default branch, plus uncommitted changes. No
+   `gh`: ask for the diff and say what you could not see. Over 1,000 lines: suggest a split.
+4. **Spec axis.** Follow the Teamwork link in the PR body, then a GitHub issue the PR or its
+   commits reference, then the PR body. Quote the requirement line for each spec finding.
+   When none of these carries requirements, say so in one line and skip this axis. Never
+   invent a requirement.
+5. **Correctness axis.** Bugs in the changed lines and in the unchanged lines of any function
+   the diff touches. Three lenses direct the investigation. Their answers reach the output only
+   as findings that survive step 6, or on the `Unverified:` line, never as narration.
+   - **Blast radius.** For every selector, class, hook, filter, or config key the diff touches,
+     search the theme, plugin, and content for the other things carrying it.
+   - **Silent failure.** For every poll, retry, timeout, fallback, or `catch`, find the branch
+     that runs when it gives up and what that branch logs. A bounded loop that expires without
+     a warning is a defect.
+   - **Removed behavior.** For every line the diff deletes or replaces, name the invariant it
+     enforced, then find where the new code re-establishes it. Nowhere is a candidate.
+6. **Verify, then deliver.** Re-read each finding against the file and vote:
+   - **CONFIRMED**: you can name the inputs or state that trigger it and the wrong result.
+     Quote the line.
+   - **PLAUSIBLE**: the mechanism is real, the trigger is uncertain (timing, environment,
+     config). State what would confirm it in the `Issue:` line.
+   - **REFUTED**: factually wrong or guarded elsewhere. Quote the line that proves it, then
+     drop the finding.
 
-Before reading anything, check whether this PR should be reviewed at all. Skip and
-say which reason applies:
+   Report CONFIRMED and PLAUSIBLE findings only. Read every ```suggestion``` block as the
+   literal replacement for its `Apply:` line. Then check each finding's form: `Issue:` holds
+   exactly one sentence; a second sentence, a worked instance, or a restated rule gets deleted
+   here, not shipped. If nothing survives, the whole review is two lines, `No issues found`
+   and one sentence naming the axes and files covered, plus `Unverified:` when needed.
+   Nothing before them, no list of what checked out. Report what you have; never invent a
+   finding to hit a count.
 
-- Closed or merged
-- Draft
-- Already reviewed by you, unless there are new commits since
-- Automated (dependency bumps, lockfile-only, generated files, release chores)
-- Trivially mechanical: pure formatting, a rename applied uniformly, comment-only
+   Delivery: a self-review returns the bare review and nothing is posted. For a PR, ask "Post
+   this review?", format the body per `references/posted-format.md`, and post in one
+   `gh api repos/{owner}/{repo}/pulls/<n>/reviews` call with `event: COMMENT`, `body`, and a
+   `comments` array of `{path, line, body}`. Always `COMMENT`: the review posts as whoever ran
+   the skill, often an automated routine, and an approve or request-changes event from that
+   account gates the PR on that person re-reviewing. The Recommendation checkboxes carry the
+   verdict instead. Use another event only when the user explicitly asks for it. Anchor each
+   finding at its `Apply:` line, or `File:` when there is no `Apply:`; findings whose anchor is
+   not in the diff stay in the body.
 
-When one applies, reply with `Skipping review:` and the reason, and stop. "Skipping
-review: lockfile bump, no reviewable logic" is a complete, correct response. Do not
-review something ineligible just because you were asked to, and do not pad the reply
-with findings to justify the turn.
+## Filters
 
-### 1. Determine target
+Do not report: anything PHPCS, PHPStan, Rector, ESLint, stylelint, or twig-lint catches (point
+at `code-standards-checker`); pre-existing issues in code the diff does not touch, including
+code it only moves; third-party behavior you did not confirm by reading it. Any claim about a
+contrib module, plugin, vendor library, or framework internal quotes the `file:line` you read.
+Never claim a check you ran only in your head; `php -l` accepts `use` after `return`. One
+structural problem outranks ten nits.
 
-- PR number given → review that PR
-- "self" / "my changes" / "before submitting" → review local changes against the
-  default branch
-- Neither → ask
-- Delegated context (prompt names a PR and says "delegated" or "automated routine")
-  → proceed without asking
+No praise, no Strengths section, and no list of what you verified, whatever the heading. No
+empty headings. No shorthand the author would have to ask about. No CANT ids, eval-case names,
+model names, or token costs in an author-facing review.
 
-### 2. Gather context
+## Self-review
 
-**PR:** in parallel, `gh pr view <n> --json title,body,baseRefName,author,additions,deletions,changedFiles`,
-`gh pr diff <n>`, `gh pr checks <n>`.
+The author's context hides the bug. Use a fresh one. Confirm the base ref resolves and the
+diff is non-empty (`git rev-parse`, `git diff --stat`); an empty diff means there is nothing
+to review, so say that and stop. Then:
 
-**Self-review:** resolve the base with
-`gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`, then in parallel
-`git log --oneline <base>..HEAD` and `git diff <base>...HEAD`.
+```
+Task(cms-cultivator:pr-review-specialist:pr-review-specialist,
+     prompt="Review the local diff. Base: <default-branch>. Head: HEAD, plus uncommitted
+             changes. Working directory: <cwd>. Output only the bare review.")
+```
 
-**No `gh`:** ask for the description and diff, review what you were given, and say
-what you could not see.
-
-Fetch the ticket too — Kanopi PR bodies link a Teamwork task, and that link is the
-spec for axis 1. With no ticket and no PR body, say so and skip axis 1 rather than
-guessing at what was asked.
-
-Size: XS <10, S 10–100, M 100–400, L 400–1,000, XL >1,000 lines. XL: suggest a split.
-
-### 3. Review on two axes
-
-**Axis 1 — Spec.** Does the diff do what the ticket and PR body say it does? Quote the
-requirement line for each finding.
-
-- A requirement with no implementation
-- A requirement implemented partially
-- A requirement implemented incorrectly: the code runs, but not what was asked
-- Scope creep: changes nothing in the ticket asked for
-
-**Axis 2 — Correctness.** Bugs, in the code the diff touched. Logic errors, unhandled
-states, wrong boundaries, broken assumptions about data or lifecycle, races across
-requests, security defects that are actually reachable.
-
-Two lenses that catch what a diff-shaped reading misses:
-
-**Blast radius.** For every selector, class, hook, filter, or config key the diff
-touches, enumerate what *else* it matches before judging the change correct. Name the
-other layouts, variants, templates, or content types that share it. A CMS block class
-is usually shared by every variant of that block, so a rule hung on the wrapper hits
-the ones the ticket never mentioned. A fix that works and quietly changes a neighbour
-is still a defect, and "the targeted case looks right" is not an answer to "what else
-matches this?"
-
-**Silent failure.** A poll, retry, timeout, fallback, or `catch` that swallows its own
-failure path leaves no signal when it stops working. Ask what the user or the next
-developer sees when the fallback is the branch that runs. A bounded loop that expires
-without a warning is a defect even when it usually succeeds.
-
-Cleanup, convention, and style findings rank below both axes and are the first cut
-when the cap binds.
-
-### 4. Filter every candidate
-
-Nothing reaches the reader without passing all three filters.
-
-#### 4a. Evidence
-
-Every finding states a concrete failure scenario: specific inputs or state leading to
-a specific wrong output, crash, or data problem. "This could be fragile" is not a
-scenario. A candidate that cannot be given one is **dropped, not softened** — hedging
-it into a "consider" bullet is how noise gets in.
-
-Any claim about the behavior of a contrib module, plugin, vendor library, or framework
-internal must cite the `file:line` in that source that you actually opened. No
-citation, no finding. Never write that you verified something you did not.
-
-Asserting third-party behavior from memory is CANT-20, and claiming a check you did
-not run is CANT-23, both in the
-[Catalog of Agent Neutralization Techniques](https://github.com/kanopi/cant).
-
-#### 4b. Confidence
-
-Score every surviving candidate 0–100 with this rubric, and report only 80 and above:
-
-- **0** — Not confident. A false positive that doesn't survive light scrutiny, or a
-  pre-existing issue.
-- **25** — Somewhat confident. Might be real, might not; you could not verify it.
-- **50** — Moderately confident. Verified real, but a nitpick or rare in practice.
-- **75** — Highly confident. Verified, very likely hit in practice, directly impacts
-  functionality.
-- **100** — Certain. Confirmed, will happen frequently, evidence directly supports it.
-
-#### 4c. CMS false-positive exclusions
-
-Do not report:
-
-1. Anything PHPCS, PHPStan, Rector, ESLint, stylelint, or twig-lint catches. CI runs
-   these; point at `code-standards-checker` instead
-2. Issues on lines the PR did not modify
-3. Pre-existing issues, including code the diff only moves
-4. Missing escaping where Twig autoescape, `wp_kses_post`, or Drupal's render layer
-   already escapes the value
-5. Missing nonce or capability checks on read-only public front-end output
-6. Missing capability checks in client-side JS — client code is untrusted by
-   definition and the check belongs server-side
-7. Absent tests for CSS, SCSS, or template-only changes
-8. Theoretical race conditions inside a single PHP request lifecycle
-9. Contrib, plugin, or vendor code the PR does not modify
-10. Any assertion about third-party behavior not confirmed by reading its source
-11. Generic "add caching" or "this may be slow" without naming the loop and the query
-12. Accessibility findings that belong to `browser-validator`, unless the diff
-    introduces the regression
-13. Missing sanitization on values that never leave a trusted context
-14. Restructuring suggestions for a file the PR touched incidentally
-
-### 5. Produce the review
-
-Report at most **8 findings**, most severe first. Correctness outranks cleanup when
-the cap forces a cut.
-
-Prefix each so required and optional are distinguishable: **Critical** (ships a bug,
-security hole, or data loss), no prefix (required before merge), **Optional** (worth
-doing, not blocking), **Nit** (author's discretion), **FYI** (no action wanted).
-
-Each finding carries the prefix, a one-line claim, `file:line`, the failure scenario,
-and the fix. Propose the move, not just the problem.
-
-Write only the sections you have content for. There is no template to fill. Never
-print an empty heading — "no security concerns" is a clause in the summary at most,
-never a section of its own.
-
-**If nothing scores 80 or above**, output `No issues found`, one line naming what you
-checked (axes, files, and anything you could not see), and stop. Do not manufacture
-suggestions to look thorough. A clean review is a real result.
-
-Close with a recommendation — approve, request changes, or comment — reasoned, not
-just a verdict. Approve when the change definitely improves code health, even if
-imperfect. Apply the 5 Cs (Context, Color, Connective Tissue, Cost, Consequence) as
-silent reasoning behind that call; do not write them out as prose.
-
-### 6. Optional: post to GitHub
-
-For a PR review, not a self-review, and only if asked: present the review, ask "Post
-this as a PR review? (approve / request changes / comment)", and on approval run
-`gh pr review <n> --<action> --body-file <file>`. Self-reviews stay local.
+Print what returns verbatim and stop: no preface, no edits, no commentary after it. Where
+agents do not exist (Claude Desktop, Codex, sandboxed evals), say so in one line and review in
+this session; the output is identical. Never spawn a second reviewer, and a spawned reviewer
+never spawns.
 
 ## Delegated mode (automated routines)
 
-When invoked from a subagent prompt, behave non-interactively:
+When the prompt names a target and says "delegated" or "automated routine": no dialogue, no
+preamble, never spawn. Output the review formatted per `references/posted-format.md`; the
+parent posts it, anchoring each finding at its `Apply:` line, or `File:` when there is no
+`Apply:`. The checked Recommendation box must match the sentinel. End with one of these
+verbatim, on its own line, because the parent parses it:
 
-- Skip step 6 entirely — do NOT post. The parent routine posts.
-- Skip all user dialogue; no user is present.
-- Output ONLY the review, with no preamble.
-- End with this exact sentinel on its own line, one of the three verbatim, because the
-  parent parses it:
     FINAL_RECOMMENDATION: Approve
     FINAL_RECOMMENDATION: Request Changes
     FINAL_RECOMMENDATION: Comment
 
-The filters in step 4 apply unchanged in delegated mode. An automated review that
-invents findings is worse than one that returns none.
+## Related skills
 
-## Related Skills
-
-- `code-standards-checker` — run before review; it owns everything in exclusion 1
-- `pr-create` — create the PR after a passing self-review
-- `pm-skills:qa-validation-checklist` — write the reviewer-facing validation steps
-  once the review passes
-- `browser-validator` — real-browser accessibility and responsive checks
+`code-standards-checker` runs before review and owns the tooling exclusion. `pr-create` opens
+the PR after a passing self-review. `pm-skills:qa-validation-checklist` writes the
+reviewer-facing steps once it passes. `browser-validator` does the real-browser accessibility
+and responsive checks.

--- a/skills/pr-review/references/posted-format.md
+++ b/skills/pr-review/references/posted-format.md
@@ -1,0 +1,43 @@
+# Posted review format
+
+Used whenever a review is posted to GitHub: step 6 posting and delegated mode. Self-reviews
+never use it.
+
+## Body
+
+```markdown
+## AI Code Review
+
+**Recommendation**
+- [ ] Approve
+- [x] Request Changes
+- [ ] Comment
+
+<verdict line>
+
+### Changes Requested
+<Critical and Important findings>
+
+### Suggestions
+<Minor findings>
+
+Unverified: <line, when present>
+```
+
+## Rules
+
+- Check exactly one Recommendation box; in delegated mode it must match the
+  `FINAL_RECOMMENDATION` sentinel. Both come from the one recommendation.
+- The GitHub review `event` is always `COMMENT` unless the user explicitly asked otherwise.
+  Reviews post as whoever ran the skill, often an automated routine, and an approve or
+  request-changes event from that account gates the PR on that person re-reviewing. The
+  checkbox, not the event, carries the recommendation.
+- Critical and Important findings go under `### Changes Requested`. Minor findings go under
+  `### Suggestions`. Omit an empty section; never print an empty heading.
+- A finding anchored to a line in the diff posts as an inline comment carrying its full
+  template and ```suggestion``` block. In the body, list it as one line: the bold headline
+  plus its `File:` value. The body stays scannable when every finding is anchored.
+- A finding with no anchor in the diff appears in full in the body under its section.
+- A `No issues found` review posts the title, the recommendation, the verdict line, and the
+  coverage line. No sections.
+- Transcribe findings without rewording. The wrapper adds structure, never new sentences.

--- a/tests/test-plugin.bats
+++ b/tests/test-plugin.bats
@@ -584,8 +584,8 @@ skip_without_agents() {
       # Public successor library (allowed reference)
       delivery-record) ;;
       *)
-        if [ ! -d "skills/$name" ]; then
-          echo "ERROR: docs/commands reference a non-existent skill: $name"
+        if [ ! -d "skills/$name" ] && [ ! -d "agents/$name" ]; then
+          echo "ERROR: docs/commands reference a non-existent skill or agent: $name"
           return 1
         fi
         ;;


### PR DESCRIPTION
## Description
Teamwork Ticket(s): none (internal plugin work; design history is in `plans/`)

> As a developer or automated routine, I need PR reviews that are short enough to read fully and specific enough to fix without follow-up questions, so that review feedback gets acted on instead of skimmed.

Fourth and final rework of the `pr-review` skill, rebuilt from scratch after three same-day attempts each fixed one complaint and introduced another. The skill now has no word or count limits anywhere: length is bounded by labeled output slots and selectivity filters, not compression. Self-review moves to a new `pr-review-specialist` leaf agent (fresh context, read-only, inherits the session model), findings are gated by verify votes backed by quoted lines instead of a self-reported confidence score, and posted reviews use a wrapper body with Recommendation checkboxes while always posting as a non-blocking comment event. The four `plans/` documents record the decisions, the adversarial agent review of the plan, and the measurements.

## Acceptance Criteria
* Every fixture review keeps all sentences inside the three labeled slots (verdict, findings, `Unverified:`)
* Every finding carries a `Fix:` that is code or one named action
* No unverified claims about vendor or framework internals; uncheckable claims land on the `Unverified:` line
* spokaneairport#310 surfaces the silent poll expiry as a finding and the containment blast radius on the `Unverified:` line
* Posted reviews never gate a PR: comment event always, recommendation carried by the checkbox
* A reader who has not seen the diff can state what to change from the review alone (human-judged)

## Assumptions
* A sonnet pin for the spawned reviewer was measured first and rejected: 0 of 6 known defects found across three fixture PRs where the session model found all of them plus new ones. The agent inherits the session model, so spawned self-reviews cost roughly what the old path cost (~$2) rather than ~$1.
* The behavioral eval harness rejects the `Agent` tool by design, so the spawn path's coverage is manual fixture runs with a transcript assertion, not CI.
* SKILL.md landed at 174 lines against the plan's ~120 target; the remaining lines are eval-driven rules each traced to an observed defect, per the plan's instruction to report the landing size rather than cut a defect-traced rule.

## Steps to Validate
1. `./scripts/validate-frontmatter.sh && node scripts/run-evals.js --min-rank1 75 && bats tests/ && ./scripts/check-codex-parity.sh` (all pass at this head: 83/83 bats, 28/28 routing)
2. `./scripts/run-behavioral-evals.sh --case pr-review--findings-are-actionable` (passes, ~$0.12, requires API access)
3. Live examples posted with this skill: kanopi/cms-cultivator#58 and #60 reviews (wrapper, inline suggestion anchors), kanopi/amca#311 and #309 (comment-default rationale)
4. From any repo with a diff: `claude --plugin-dir <this-checkout>` then `/pr-review self`, and confirm the specialist agent spawns and the returned review is verdict, findings, `Unverified:` only

## Affected URL
n/a (Claude Code plugin; exercised via the fixture PRs linked above)

## Deploy Notes
None for deployment. Merging is not a release: the skill ships to users on the next version bump via `/pr-release`. Codex parity artifacts for the new agent are included.

Tests run this session: bats 83/83, routing evals 28/28, frontmatter validation, Codex parity, and the behavioral eval case all pass; three fixture reviews were run through the real spawn path with measured word counts (330-497 prose words, findings doubled to tripled against baseline).

- [x] Was AI used in this pull request?