### PR TITLE
fix(worktree-manager): handle the half-success in `git worktree remove`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `worktree-manager`: the remove workflow assumed `git worktree remove` either
+  succeeds or fails cleanly. It does neither — it deletes the tracked tree, then
+  refuses to delete ignored files (`node_modules/`, `vendor/`, build caches) and
+  exits non-zero with `Directory not empty`. Because step 3 runs `git worktree
+  prune` immediately after, the registration is cleared and `git worktree list`
+  reports clean while the directory survives on disk, so every subsequent check
+  agrees the teardown worked. Found on a real teardown that left 253M behind.
+  Step 3 now requires checking the exit code, and gives the three proofs to run
+  before `rm -rf`: the path is no longer a registered worktree, a diff against
+  the main clone shows nothing unique, and the path is guarded so a bad variable
+  cannot expand into something catastrophic. Notes that `git status --porcelain`
+  cannot warn about this, since it hides the ignored files that cause it.
+
+### Changed
+
+- `worktree-manager`: the remove confirmation gate now reports the branch the
+  directory actually has checked out rather than trusting the folder name.
+  Checkouts get reused, so `<repo>-tw1234` need not still hold tw1234's branch —
+  and the ticket the user named may have no worktree at all. Without this the
+  gate can describe tearing down one ticket while it tears down another.
+- `worktree-manager`: added post-remove quality gates. Confirming a teardown now
+  means checking the directory is gone from disk as well as from `git worktree
+  list`, that `ddev list` no longer shows the project, and that `-BAK` branches
+  and stashes survived — stashes are shared across worktrees via the main
+  clone's `refs/stash`, so their disappearance means something over-deleted.
+
 ## [2.4.0] - 2026-08-16
 
 ### Changed

--- a/skills/worktree-manager/SKILL.md
+++ b/skills/worktree-manager/SKILL.md
@@ -111,6 +111,12 @@ If platform is ambiguous (no `.ddev/`, no `next.config.*`), ask which platform i
 
 **Confirmation gate:** state exactly what will be deleted (worktree directory, local branch if merged, DDEV project + database) and wait for explicit approval before proceeding.
 
+**Report the branch, not the folder name.** Nothing enforces that `<repo>-tw1234` still contains tw1234's branch — checkouts get reused, and the ticket the user names may have no worktree at all. Resolve it before quoting anything back:
+```bash
+git -C ../<repo>-tw<id> branch --show-current
+```
+If it disagrees with the ticket the user asked for, say so and let them confirm the target. Otherwise the gate describes tearing down one ticket while it actually tears down another.
+
 1. **Verify the branch is merged** (or the user confirms abandoning it):
    ```bash
    git branch --merged main | grep <type>/tw<id>
@@ -124,6 +130,21 @@ If platform is ambiguous (no `.ddev/`, no `next.config.*`), ask which platform i
    git worktree remove ../<repo>-tw<id>
    git worktree prune
    ```
+   **Check the exit code — this command half-succeeds.** It deletes tracked files but refuses to delete ignored ones, so on any repo with `node_modules/`, `vendor/`, `playwright-report/` or a build cache it fails with `error: failed to delete '<path>': Directory not empty` *after* the tracked tree is already gone. `git worktree prune` then clears the registration, so `git worktree list` reports clean while the directory is still on disk — a silent orphan (253M in the case this was found). `git status --porcelain` will not have warned you: it hides ignored files, so the checkout reads as "0 changes" right up until removal fails.
+
+   Finishing it means `rm -rf`, so prove the directory is disposable first:
+   ```bash
+   # a. It must not still be a registered worktree, or this is live work.
+   [ -d <main>/.git/worktrees/<repo>-tw<id> ] && echo "ABORT: still registered"
+
+   # b. Nothing unique may remain — compare against the main clone.
+   diff <(cd <orphan> && find . -type f -not -path './node_modules/*' -not -path './.git/*' | sort) \
+        <(cd <main>   && find . -type f -not -path './node_modules/*' -not -path './.git/*' | sort)
+
+   # c. Guard the path so a bad variable cannot expand into something catastrophic.
+   case "$D" in <expected absolute path>) rm -rf "$D";; *) echo "ABORT: unexpected path"; exit 1;; esac
+   ```
+   Expect (b) to report only DDEV's generated `.ddev/traefik/` certs and config for the deleted project, plus the orphaned `.git` pointer file. Anything else — an untracked script, a `.env`, an unread report — stops the deletion until the user has seen it.
 4. **Delete the local branch** once merged (mirrors Kanopi's branch-cleanup discipline):
    ```bash
    git branch -d <type>/tw<id>-<short-desc>
@@ -139,8 +160,14 @@ Before reporting a create as complete:
 
 Before a remove:
 1. ✅ User explicitly approved the deletion
-2. ✅ Branch is merged, or user confirmed abandoning unmerged work
-3. ✅ DDEV project torn down before the directory is removed
+2. ✅ The branch actually checked out in that directory was reported, and is the one the user means
+3. ✅ Branch is merged, or user confirmed abandoning unmerged work
+4. ✅ DDEV project torn down before the directory is removed
+
+After a remove — a half-finished teardown reports success, so confirm each layer:
+5. ✅ `git worktree list` no longer lists it **and** the directory is absent from disk (`ls -d <path>`)
+6. ✅ `ddev list` no longer shows the project
+7. ✅ The local branch is gone, and any `-BAK` branches and stashes still exist (stashes live in the main clone's `refs/stash` and are shared across worktrees — if they vanished, something deleted more than it should have)
 
 ## Notes
 


### PR DESCRIPTION
Found while tearing down a real worktree. The skill reported a clean removal and 253M was still on disk.

## The bug

`git worktree remove` is not atomic. It deletes the tracked tree, then refuses to delete **ignored** files — `node_modules/`, `vendor/`, `playwright-report/`, build caches — and exits non-zero:

```
error: failed to delete '/Users/…/amca-tw30058098': Directory not empty
```

Step 3 ran `git worktree prune` on the next line regardless. Prune clears the registration, so from that point on:

| Check | Says | Reality |
|---|---|---|
| `git worktree list` | gone | directory present |
| `herdr worktree list` | gone | directory present |
| `ls` | — | 253M still there |

The skill's own verification agreed with the wrong answer. Nothing in the workflow could catch it, because everything it consulted had just been pruned.

`git status --porcelain` doesn't help either — it hides ignored files, so the checkout read as "0 changes" right up until removal failed. That's now stated explicitly, since it's the check most people would reach for.

## What changed

**Step 3** — check the exit code, and prove the directory is disposable before `rm -rf`: (a) it is no longer a registered worktree, (b) a diff against the main clone shows nothing unique, (c) the path is guarded by a `case` so a bad variable can't expand into something catastrophic. Expect (b) to show only DDEV's generated `.ddev/traefik/` certs and the orphaned `.git` pointer; anything else stops the deletion.

**Confirmation gate** — report the branch the directory actually has checked out, not the folder name. In the case that prompted this, `amca-tw30058098` had `update/ep-block-bindings-tw30058086` checked out, and the real tw30058098 branch existed only on the remote with no worktree at all. Removing by folder name would have told the developer one ticket was being torn down while another actually was.

**Quality Gates** — a post-remove block, since a half-finished teardown reports success. Confirms the directory is gone from disk *and* the worktree list, the DDEV project is gone, and that `-BAK` branches and stashes **survived** — stashes live in the main clone's `refs/stash` and are shared across worktrees, so their disappearance means something over-deleted.

## Scope

Documentation-only, inside one skill. No behaviour change to `create` or `list`. Per `CLAUDE.md`, the registry files (`skills/README.md`, `evals/routing-prompts.json`, `docs/agents-and-skills.md`) are only updated when a skill is **added**, so this touches `SKILL.md` and `CHANGELOG.md` (`[Unreleased]`, which the file did not previously have a section for).

## Testing

- `tests/test-plugin.bats` — **68/68 pass**
- `scripts/validate-frontmatter.sh` — 0 errors
- `scripts/check-codex-parity.sh` — in parity

Worth flagging for CI: these three all fail *silently and misleadingly* without their dependencies. `jq`, `nodejs` and `python3` missing produce 12 bats failures that look like real assertion failures, and a Python without `PyYAML` makes both YAML tests fail with `ModuleNotFoundError` while `validate-frontmatter.sh` reports "41 errors" and still **exits 0**. I only got a true result after installing `jq nodejs bash python3 py3-yaml`. Happy to open a separate issue if that exit-code bug isn't already known.

- [x] Was AI used in this pull request?